### PR TITLE
회원 테이블 컬럼 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -46,6 +47,12 @@ public class Member {
     private Department department;
 
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
 
+    @PrePersist
+    public void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -42,7 +42,7 @@ public class Member {
     private String studentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "department")
+    @JoinColumn(name = "department_id")
     private Department department;
 
     @Column(name = "created_at", nullable = false)


### PR DESCRIPTION
- createdAt 초기화 방식 수정
   - builder 패턴에 따른 createdAt 필드 초기화가 되지 않는 문제
   - PrePersist를 통해 회원 저장시 자동 주입
- 학과 컬럼명에 `_id`추가