### PR TITLE
Soft Delete 구현을 위한 BaseEntity 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -1,0 +1,15 @@
+package com.dongsoop.dongsoop.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
+    private boolean isDeleted = false;
+
+    public void setDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -18,12 +18,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("is_deleted = false")
 @Table(name = "member")
 public class Member extends BaseEntity {
 

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.member.entity;
 
+import com.dongsoop.dongsoop.common.BaseEntity;
 import com.dongsoop.dongsoop.department.entity.Department;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,7 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Table(name = "member")
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)


### PR DESCRIPTION
Close #25 

## 작업 내용

- [x] 추상 클래스 BaseEntity 구현
  - [x] isDelete 필드 추가
- [x] Member 클래스가 BaseEntity를 상속받도록 수정
- [x] Member 클래스에서 모든 쿼리 호출 시 is_delete 값을 확인하여 제거되지 않은 데이터만 선택하도록 개선