### PR TITLE
서버에서 발생하는 에러 로그를 Discord Web Hook을 통해 실시간 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -33,6 +34,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.jsoup:jsoup:1.15.3'
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,40 @@
+<configuration debug="true">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- 콘솔 로깅 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <!-- 디스코드 웹훅 로깅 설정 -->
+    <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-url" defaultValue=""/>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>
+            https://discord.com/api/webhooks/1369530910864838717/LXZMjuiIgXj1oqaRYrxa3a7eJJReOxWBCcYXh1dUlHhBJb4N-DemY2C0HIa_arKPgbfW
+        </webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+        </layout>
+        <username>에러 났다~</username>
+        <tts>false</tts>
+    </appender>
+
+    <!-- 디스코드 비동기 처리 설정 (ERROR 레벨 이상만) -->
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <logger name="com.github.napstr.logback" level="DEBUG"/>
+
+    <!-- 루트 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
         </layout>
-        <username>에러 났다~</username>
+        <username>에러 알리미</username>
         <tts>false</tts>
     </appender>
 


### PR DESCRIPTION
### 주요 변경사항
- Logback 설정 파일에 Discord 웹훅 어펜더 추가
- ERROR 레벨 이상의 로그만 Discord로 전송되도록 필터링 설정
- 비동기 처리를 통한 서버 성능 영향 최소화
- 타임스탬프, 스레드, 로그 레벨 및 전체 스택 트레이스가 포함된 포맷 적용
- Discord 로깅 기능을 위한 외부 라이브러리 의존성 추가 (logback-discord-appender)