### PR TITLE
튜터링 게시판 생성 및 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
     mavenCentral()
 }
 
+def querydslDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -38,6 +48,12 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
 
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -46,4 +62,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -21,8 +21,8 @@ public abstract class RecruitmentBoard extends Board {
     private LocalDateTime endAt;
 
     @NotNull
-    @Column(name = "recruitment_capacity", nullable = false, columnDefinition = "INT DEFAULT 0")
-    private Integer recruitmentCapacity;
+    @Column(name = "capacity", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer capacity;
 
     @Column(name = "tags", length = 100)
     private String tags;

--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +13,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class BaseEntity {
 
     @Setter
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
     private boolean isDeleted = false;
 }

--- a/src/main/java/com/dongsoop/dongsoop/common/PageableUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/PageableUtil.java
@@ -29,6 +29,10 @@ public class PageableUtil {
     }
 
     private Order getOrder(Sort.Order order) {
-        return order.isAscending() ? Order.ASC : Order.DESC;
+        if (order.isDescending()) {
+            return Order.DESC;
+        }
+
+        return Order.ASC;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/common/PageableUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/PageableUtil.java
@@ -1,0 +1,34 @@
+package com.dongsoop.dongsoop.common;
+
+import com.dongsoop.dongsoop.tutoring.entity.QTutoringBoard;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PageableUtil {
+
+    public OrderSpecifier<?>[] getAllOrderSpecifiers(Sort sort) {
+        return sort.stream()
+                .map(order -> toOrderSpecifier(order, QTutoringBoard.tutoringBoard))
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private OrderSpecifier<?> toOrderSpecifier(Sort.Order order, QTutoringBoard root) {
+        PathBuilder<?> entityPath = new PathBuilder<>(root.getType(), root.getMetadata());
+        String[] properties = order.getProperty().split("\\.");
+
+        for (int i = 0; i < properties.length - 1; i++) {
+            entityPath = entityPath.get(properties[i]);
+        }
+
+        String last = properties[properties.length - 1];
+        return new OrderSpecifier<>(getOrder(order), entityPath.getComparable(last, Comparable.class));
+    }
+
+    private Order getOrder(Sort.Order order) {
+        return order.isAscending() ? Order.ASC : Order.DESC;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/config/QuerydslConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.dongsoop.dongsoop.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/DurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/DurationValidator.java
@@ -17,13 +17,13 @@ public abstract class DurationValidator<A extends Annotation> implements Constra
     @Override
     public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
         try {
-            setUp(object);
+            if (setUp(object)) {
+                return true;
+            }
 
             return validateDuration();
-        } catch (NoSuchFieldException e) {
+        } catch (Exception e) {
             return false;
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/date/DurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/DurationValidator.java
@@ -1,0 +1,46 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+public abstract class DurationValidator<A extends Annotation> implements ConstraintValidator<A, Object> {
+
+    protected Long value;
+    protected LocalDateTime startDateTime;
+    protected LocalDateTime endDateTime;
+    protected String startFieldName;
+    protected String endFieldName;
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            setUp(object);
+
+            return validateDuration();
+        } catch (NoSuchFieldException e) {
+            return false;
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected boolean setUp(Object object) throws NoSuchFieldException, IllegalAccessException {
+        Field startField = object.getClass()
+                .getDeclaredField(this.startFieldName);
+        Field endField = object.getClass()
+                .getDeclaredField(this.endFieldName);
+
+        startField.setAccessible(true);
+        endField.setAccessible(true);
+
+        startDateTime = (LocalDateTime) startField.get(object);
+        endDateTime = (LocalDateTime) endField.get(object);
+
+        return this.startDateTime == null || this.endDateTime == null; // null 검증은 @NotNull 에서 처리
+    }
+
+    protected abstract boolean validateDuration();
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAt.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAt.java
@@ -12,6 +12,10 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = {EndAtAfterStartAtValidator.class})
 public @interface EndAtAfterStartAt {
 
+    String start() default "startAt";
+
+    String end() default "endAt";
+
     String message() default "시작일이 종료일보다 늦을 수 없습니다";
 
     Class<?>[] groups() default {};

--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAt.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAt.java
@@ -1,0 +1,20 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {EndAtAfterStartAtValidator.class})
+public @interface EndAtAfterStartAt {
+
+    String message() default "시작일이 종료일보다 늦을 수 없습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
@@ -1,0 +1,28 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDateTime;
+
+public class EndAtAfterStartAtValidator implements ConstraintValidator<EndAtAfterStartAt, Object> {
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            LocalDateTime startAt = (LocalDateTime) object.getClass()
+                    .getMethod("getStartAt")
+                    .invoke(object);
+            LocalDateTime endAt = (LocalDateTime) object.getClass()
+                    .getMethod("getEndAt")
+                    .invoke(object);
+
+            if (startAt == null || endAt == null) {
+                return true; // null 검증은 @NotNull 에서 처리
+            }
+
+            return endAt.isAfter(startAt);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
@@ -2,26 +2,41 @@ package com.dongsoop.dongsoop.date;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class EndAtAfterStartAtValidator implements ConstraintValidator<EndAtAfterStartAt, Object> {
+
+    private String startFieldName;
+
+    private String endFieldName;
+
+    @Override
+    public void initialize(EndAtAfterStartAt constraintAnnotation) {
+        this.startFieldName = constraintAnnotation.start();
+        this.endFieldName = constraintAnnotation.end();
+    }
 
     @Override
     public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
         try {
-            LocalDateTime startAt = (LocalDateTime) object.getClass()
-                    .getMethod("getStartAt")
-                    .invoke(object);
-            LocalDateTime endAt = (LocalDateTime) object.getClass()
-                    .getMethod("getEndAt")
-                    .invoke(object);
+            Field startField = object.getClass().getDeclaredField(startFieldName);
+            Field endField = object.getClass().getDeclaredField(endFieldName);
 
+            startField.setAccessible(true);
+            endField.setAccessible(true);
+
+            LocalDateTime startAt = (LocalDateTime) startField.get(object);
+            LocalDateTime endAt = (LocalDateTime) endField.get(object);
             if (startAt == null || endAt == null) {
                 return true; // null 검증은 @NotNull 에서 처리
             }
 
             return endAt.isAfter(startAt);
         } catch (Exception e) {
+            log.error(e.getMessage(), e);
             return false;
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDate.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDate.java
@@ -1,0 +1,30 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {MaxDateValidator.class})
+public @interface MaxDate {
+
+    int year() default 0;
+
+    int month() default 0;
+
+    int day() default 0;
+
+    int hour() default 0;
+
+    int minute() default 0;
+
+    String message() default "날짜가 유효하지 않습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDateValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDateValidator.java
@@ -1,0 +1,43 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDateTime;
+
+public class MaxDateValidator implements ConstraintValidator<MaxDate, LocalDateTime> {
+
+    private int year;
+
+    private int month;
+
+    private int day;
+
+    private int hour;
+
+    private int minute;
+
+    @Override
+    public void initialize(MaxDate constraintAnnotation) {
+        this.year = constraintAnnotation.year();
+        this.month = constraintAnnotation.month();
+        this.day = constraintAnnotation.day();
+        this.hour = constraintAnnotation.hour();
+        this.minute = constraintAnnotation.minute();
+    }
+
+    @Override
+    public boolean isValid(LocalDateTime value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null) {
+            return true;
+        }
+
+        LocalDateTime now = LocalDateTime.now()
+                .plusMinutes(this.minute)
+                .plusHours(this.hour)
+                .plusDays(this.day)
+                .plusMonths(this.month)
+                .plusYears(this.year);
+
+        return value.isBefore(now) || value.isEqual(now);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDuration.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDuration.java
@@ -18,7 +18,7 @@ public @interface MaxDuration {
 
     String end() default "endAt";
 
-    String message() default "시작일이 종료일보다 늦을 수 없습니다";
+    String message() default "최대 설정 가능 기간보다 길 수 없습니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDuration.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDuration.java
@@ -1,0 +1,26 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {MaxDurationValidator.class})
+public @interface MaxDuration {
+
+    long value() default 2419200L; // 기본 최대 4주 (60 * 60 * 24 * 28일)
+
+    String start() default "startAt";
+
+    String end() default "endAt";
+
+    String message() default "시작일이 종료일보다 늦을 수 없습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDurationValidator.java
@@ -1,17 +1,12 @@
 package com.dongsoop.dongsoop.date;
 
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 
-public class MaxDurationValidator implements ConstraintValidator<MaxDuration, Object> {
+public class MaxDurationValidator extends DurationValidator<MaxDuration> {
 
-    private Long value;
-
-    private String startFieldName;
-
-    private String endFieldName;
+    public MaxDurationValidator() {
+        super();
+    }
 
     @Override
     public void initialize(MaxDuration constraintAnnotation) {
@@ -21,23 +16,8 @@ public class MaxDurationValidator implements ConstraintValidator<MaxDuration, Ob
     }
 
     @Override
-    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
-        try {
-            Field startField = object.getClass()
-                    .getDeclaredField(startFieldName);
-            Field endField = object.getClass()
-                    .getDeclaredField(endFieldName);
-
-            startField.setAccessible(true);
-            endField.setAccessible(true);
-
-            LocalDateTime startAt = (LocalDateTime) startField.get(object);
-            LocalDateTime endAt = (LocalDateTime) endField.get(object);
-
-            LocalDateTime maxTime = startAt.plusSeconds(this.value);
-            return endAt.isBefore(maxTime) || endAt.equals(maxTime);
-        } catch (Exception e) {
-            return false;
-        }
+    public boolean validateDuration() {
+        LocalDateTime maxTime = startDateTime.plusSeconds(this.value);
+        return endDateTime.isBefore(maxTime) || endDateTime.equals(maxTime);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/date/MaxDurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MaxDurationValidator.java
@@ -1,0 +1,43 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+public class MaxDurationValidator implements ConstraintValidator<MaxDuration, Object> {
+
+    private Long value;
+
+    private String startFieldName;
+
+    private String endFieldName;
+
+    @Override
+    public void initialize(MaxDuration constraintAnnotation) {
+        this.value = constraintAnnotation.value();
+        this.startFieldName = constraintAnnotation.start();
+        this.endFieldName = constraintAnnotation.end();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            Field startField = object.getClass()
+                    .getDeclaredField(startFieldName);
+            Field endField = object.getClass()
+                    .getDeclaredField(endFieldName);
+
+            startField.setAccessible(true);
+            endField.setAccessible(true);
+
+            LocalDateTime startAt = (LocalDateTime) startField.get(object);
+            LocalDateTime endAt = (LocalDateTime) endField.get(object);
+
+            LocalDateTime maxTime = startAt.plusSeconds(this.value);
+            return endAt.isBefore(maxTime) || endAt.equals(maxTime);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MinDuration.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MinDuration.java
@@ -18,7 +18,7 @@ public @interface MinDuration {
 
     String end() default "endAt";
 
-    String message() default "시작일이 종료일보다 늦을 수 없습니다";
+    String message() default "최소 설정 가능 기간보다 짧을 수 없습니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/dongsoop/dongsoop/date/MinDuration.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MinDuration.java
@@ -1,0 +1,26 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {MinDurationValidator.class})
+public @interface MinDuration {
+
+    long value() default 86400L;
+
+    String start() default "startAt";
+
+    String end() default "endAt";
+
+    String message() default "시작일이 종료일보다 늦을 수 없습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MinDurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MinDurationValidator.java
@@ -1,0 +1,47 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+public class MinDurationValidator implements ConstraintValidator<MinDuration, Object> {
+
+    private Long value;
+
+    private String startFieldName;
+
+    private String endFieldName;
+
+    @Override
+    public void initialize(MinDuration constraintAnnotation) {
+        this.value = constraintAnnotation.value();
+        this.startFieldName = constraintAnnotation.start();
+        this.endFieldName = constraintAnnotation.end();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            Field startField = object.getClass()
+                    .getDeclaredField(startFieldName);
+            Field endField = object.getClass()
+                    .getDeclaredField(endFieldName);
+
+            startField.setAccessible(true);
+            endField.setAccessible(true);
+
+            LocalDateTime startAt = (LocalDateTime) startField.get(object);
+            LocalDateTime endAt = (LocalDateTime) endField.get(object);
+
+            if (startAt == null || endAt == null) {
+                return true; // null 검증은 @NotNull 에서 처리
+            }
+
+            LocalDateTime minTime = endAt.minusSeconds(this.value);
+            return startAt.isBefore(minTime) || startAt.equals(minTime);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/MinDurationValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/MinDurationValidator.java
@@ -1,17 +1,12 @@
 package com.dongsoop.dongsoop.date;
 
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 
-public class MinDurationValidator implements ConstraintValidator<MinDuration, Object> {
+public class MinDurationValidator extends DurationValidator<MinDuration> {
 
-    private Long value;
-
-    private String startFieldName;
-
-    private String endFieldName;
+    public MinDurationValidator() {
+        super();
+    }
 
     @Override
     public void initialize(MinDuration constraintAnnotation) {
@@ -21,27 +16,8 @@ public class MinDurationValidator implements ConstraintValidator<MinDuration, Ob
     }
 
     @Override
-    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
-        try {
-            Field startField = object.getClass()
-                    .getDeclaredField(startFieldName);
-            Field endField = object.getClass()
-                    .getDeclaredField(endFieldName);
-
-            startField.setAccessible(true);
-            endField.setAccessible(true);
-
-            LocalDateTime startAt = (LocalDateTime) startField.get(object);
-            LocalDateTime endAt = (LocalDateTime) endField.get(object);
-
-            if (startAt == null || endAt == null) {
-                return true; // null 검증은 @NotNull 에서 처리
-            }
-
-            LocalDateTime minTime = endAt.minusSeconds(this.value);
-            return startAt.isBefore(minTime) || startAt.equals(minTime);
-        } catch (Exception e) {
-            return false;
-        }
+    public boolean validateDuration() {
+        LocalDateTime minTime = endDateTime.minusSeconds(this.value);
+        return startDateTime.isBefore(minTime) || startDateTime.equals(minTime);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/date/TodayOrFuture.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/TodayOrFuture.java
@@ -1,0 +1,20 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {TodayOrFutureValidator.class})
+public @interface TodayOrFuture {
+
+    String message() default "오늘보다 과거일 수 없습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dongsoop/dongsoop/date/TodayOrFutureValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/TodayOrFutureValidator.java
@@ -10,10 +10,12 @@ public class TodayOrFutureValidator implements ConstraintValidator<TodayOrFuture
     @Override
     public boolean isValid(LocalDateTime value, ConstraintValidatorContext context) {
         if (value == null) {
-            return true;
+            return false;
         }
+
         LocalDate today = LocalDate.now();
-        return !value.toLocalDate()
-                .isBefore(today);
+        LocalDate valueDate = value.toLocalDate();
+
+        return today.equals(valueDate) || today.isBefore(valueDate);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/date/TodayOrFutureValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/TodayOrFutureValidator.java
@@ -1,0 +1,19 @@
+package com.dongsoop.dongsoop.date;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TodayOrFutureValidator implements ConstraintValidator<TodayOrFuture, LocalDateTime> {
+
+    @Override
+    public boolean isValid(LocalDateTime value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        LocalDate today = LocalDate.now();
+        return !value.toLocalDate()
+                .isBefore(today);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/tutoring/TutoringBoardNotFound.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/tutoring/TutoringBoardNotFound.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.tutoring;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TutoringBoardNotFound extends CustomException {
+
+    public TutoringBoardNotFound(Long id) {
+        super("존재하지 않는 튜터링 게시글입니다: " + id, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.jsoup.internal.StringUtil;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -124,7 +123,7 @@ public class MemberService {
         Authentication authentication = SecurityContextHolder.getContext()
                 .getAuthentication();
         String id = authentication.getName();
-        if (StringUtils.hasText(id) && StringUtil.isNumeric(id)) {
+        if (StringUtils.hasText(id) && id.matches("\\d+")) {
             return (Long) authentication.getPrincipal();
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -1,146 +1,18 @@
 package com.dongsoop.dongsoop.member.service;
 
-import com.dongsoop.dongsoop.department.entity.Department;
-import com.dongsoop.dongsoop.department.entity.DepartmentType;
-import com.dongsoop.dongsoop.department.service.DepartmentService;
-import com.dongsoop.dongsoop.exception.domain.member.EmailDuplicatedException;
-import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
-import com.dongsoop.dongsoop.jwt.TokenGenerator;
 import com.dongsoop.dongsoop.jwt.dto.TokenIssueResponse;
 import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
 import com.dongsoop.dongsoop.member.dto.LoginRequest;
 import com.dongsoop.dongsoop.member.dto.SignupRequest;
 import com.dongsoop.dongsoop.member.entity.Member;
-import com.dongsoop.dongsoop.member.repository.MemberRepository;
-import com.dongsoop.dongsoop.role.entity.MemberRole;
-import com.dongsoop.dongsoop.role.entity.Role;
-import com.dongsoop.dongsoop.role.entity.RoleType;
-import com.dongsoop.dongsoop.role.repository.MemberRoleRepository;
-import com.dongsoop.dongsoop.role.repository.RoleRepository;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
-@Service
-@RequiredArgsConstructor
-public class MemberService {
+public interface MemberService {
 
-    private final MemberRepository memberRepository;
+    void signup(SignupRequest request);
 
-    private final RoleRepository roleRepository;
+    TokenIssueResponse login(LoginRequest loginRequest);
 
-    private final MemberRoleRepository memberRoleRepository;
+    LoginAuthenticate getLoginAuthenticateByNickname(String nickname);
 
-    private final DepartmentService departmentService;
-
-    private final PasswordEncoder passwordEncoder;
-
-    private final TokenGenerator tokenGenerator;
-
-    @Transactional
-    public void signup(SignupRequest request) {
-        checkEmailDuplication(request.getEmail());
-
-        Member member = transformToMemberBySignupRequest(request);
-        memberRepository.save(member);
-
-        Role userRole = roleRepository.findByRoleType(RoleType.USER);
-        MemberRole memberRole = new MemberRole(member, userRole);
-        memberRoleRepository.save(memberRole);
-    }
-
-    private Member transformToMemberBySignupRequest(SignupRequest request) {
-        String email = request.getEmail();
-        String nickname = request.getNickname();
-        String studentId = request.getStudentId();
-        DepartmentType departmentType = request.getDepartmentType();
-
-        Department proxyDepartment = departmentService.getReferenceById(departmentType);
-
-        return Member.builder()
-                .email(email)
-                .password(passwordEncoder.encode(request.getPassword()))
-                .nickname(nickname)
-                .studentId(studentId)
-                .department(proxyDepartment)
-                .build();
-    }
-
-    public TokenIssueResponse login(LoginRequest loginRequest) {
-        LoginAuthenticate loginAuthenticate = getLoginAuthenticate(loginRequest.getEmail());
-
-        String password = loginAuthenticate.getPassword();
-        validatePassword(loginRequest.getPassword(), password);
-
-        Authentication authentication = getAuthenticationByLoginAuthenticate(loginAuthenticate);
-
-        String accessToken = tokenGenerator.generateAccessToken(authentication);
-        String refreshToken = tokenGenerator.generateRefreshToken(authentication);
-
-        return new TokenIssueResponse(accessToken, refreshToken);
-    }
-
-    private Authentication getAuthenticationByLoginAuthenticate(LoginAuthenticate loginAuthenticate) {
-        Long id = loginAuthenticate.getId();
-        List<Role> roleList = memberRoleRepository.findAllByMemberId(id);
-        Collection<GrantedAuthority> role = getAuthoritiesByRoleList(roleList);
-
-        return new UsernamePasswordAuthenticationToken(id, null, role);
-    }
-
-    private Collection<GrantedAuthority> getAuthoritiesByRoleList(List<Role> roleList) {
-        return roleList.stream()
-                .map(Role::getRoleType)
-                .map(RoleType::getAuthority)
-                .toList();
-    }
-
-    private LoginAuthenticate getLoginAuthenticate(String email) {
-        Optional<LoginAuthenticate> optionalAuthenticate = memberRepository.findLoginAuthenticateByEmail(email);
-        return optionalAuthenticate.orElseThrow(MemberNotFoundException::new);
-    }
-
-    public LoginAuthenticate getLoginAuthenticateByNickname(String nickname) {
-        Optional<LoginAuthenticate> optionalAuthenticate = memberRepository.findLoginAuthenticateByNickname(nickname);
-        return optionalAuthenticate.orElseThrow(MemberNotFoundException::new);
-    }
-
-    public Member getMemberReferenceByContext() {
-        Long id = getMemberIdByContext();
-        return memberRepository.getReferenceById(id);
-    }
-
-    private Long getMemberIdByContext() {
-        Authentication authentication = SecurityContextHolder.getContext()
-                .getAuthentication();
-        String id = authentication.getName();
-        if (StringUtils.hasText(id) && id.matches("\\d+")) {
-            return (Long) authentication.getPrincipal();
-        }
-
-        throw new MemberNotFoundException();
-    }
-
-    private void validatePassword(String loginPassword, String password) {
-        if (!passwordEncoder.matches(loginPassword, password)) {
-            throw new MemberNotFoundException();
-        }
-    }
-
-    private void checkEmailDuplication(String email) {
-        boolean isExists = memberRepository.existsByEmail(email);
-
-        if (isExists) {
-            throw new EmailDuplicatedException();
-        }
-    }
+    Member getMemberReferenceByContext();
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -124,7 +124,7 @@ public class MemberServiceImpl implements MemberService {
                 .getAuthentication();
         String id = authentication.getName();
         if (StringUtils.hasText(id) && id.matches("\\d+")) {
-            return (Long) authentication.getPrincipal();
+            return Long.valueOf(id);
         }
 
         throw new MemberNotFoundException();

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.service.DepartmentService;
 import com.dongsoop.dongsoop.exception.domain.member.EmailDuplicatedException;
+import com.dongsoop.dongsoop.exception.domain.member.InvalidPasswordFormatException;
 import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
 import com.dongsoop.dongsoop.jwt.TokenGenerator;
 import com.dongsoop.dongsoop.jwt.dto.TokenIssueResponse;
@@ -132,7 +133,7 @@ public class MemberServiceImpl implements MemberService {
 
     private void validatePassword(String loginPassword, String password) {
         if (!passwordEncoder.matches(loginPassword, password)) {
-            throw new MemberNotFoundException();
+            throw new InvalidPasswordFormatException();
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -1,0 +1,146 @@
+package com.dongsoop.dongsoop.member.service;
+
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.department.service.DepartmentService;
+import com.dongsoop.dongsoop.exception.domain.member.EmailDuplicatedException;
+import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
+import com.dongsoop.dongsoop.jwt.TokenGenerator;
+import com.dongsoop.dongsoop.jwt.dto.TokenIssueResponse;
+import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
+import com.dongsoop.dongsoop.member.dto.LoginRequest;
+import com.dongsoop.dongsoop.member.dto.SignupRequest;
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.repository.MemberRepository;
+import com.dongsoop.dongsoop.role.entity.MemberRole;
+import com.dongsoop.dongsoop.role.entity.Role;
+import com.dongsoop.dongsoop.role.entity.RoleType;
+import com.dongsoop.dongsoop.role.repository.MemberRoleRepository;
+import com.dongsoop.dongsoop.role.repository.RoleRepository;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final RoleRepository roleRepository;
+
+    private final MemberRoleRepository memberRoleRepository;
+
+    private final DepartmentService departmentService;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final TokenGenerator tokenGenerator;
+
+    @Transactional
+    public void signup(SignupRequest request) {
+        checkEmailDuplication(request.getEmail());
+
+        Member member = transformToMemberBySignupRequest(request);
+        memberRepository.save(member);
+
+        Role userRole = roleRepository.findByRoleType(RoleType.USER);
+        MemberRole memberRole = new MemberRole(member, userRole);
+        memberRoleRepository.save(memberRole);
+    }
+
+    private Member transformToMemberBySignupRequest(SignupRequest request) {
+        String email = request.getEmail();
+        String nickname = request.getNickname();
+        String studentId = request.getStudentId();
+        DepartmentType departmentType = request.getDepartmentType();
+
+        Department proxyDepartment = departmentService.getReferenceById(departmentType);
+
+        return Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(request.getPassword()))
+                .nickname(nickname)
+                .studentId(studentId)
+                .department(proxyDepartment)
+                .build();
+    }
+
+    public TokenIssueResponse login(LoginRequest loginRequest) {
+        LoginAuthenticate loginAuthenticate = getLoginAuthenticate(loginRequest.getEmail());
+
+        String password = loginAuthenticate.getPassword();
+        validatePassword(loginRequest.getPassword(), password);
+
+        Authentication authentication = getAuthenticationByLoginAuthenticate(loginAuthenticate);
+
+        String accessToken = tokenGenerator.generateAccessToken(authentication);
+        String refreshToken = tokenGenerator.generateRefreshToken(authentication);
+
+        return new TokenIssueResponse(accessToken, refreshToken);
+    }
+
+    private Authentication getAuthenticationByLoginAuthenticate(LoginAuthenticate loginAuthenticate) {
+        Long id = loginAuthenticate.getId();
+        List<Role> roleList = memberRoleRepository.findAllByMemberId(id);
+        Collection<GrantedAuthority> role = getAuthoritiesByRoleList(roleList);
+
+        return new UsernamePasswordAuthenticationToken(id, null, role);
+    }
+
+    private Collection<GrantedAuthority> getAuthoritiesByRoleList(List<Role> roleList) {
+        return roleList.stream()
+                .map(Role::getRoleType)
+                .map(RoleType::getAuthority)
+                .toList();
+    }
+
+    private LoginAuthenticate getLoginAuthenticate(String email) {
+        Optional<LoginAuthenticate> optionalAuthenticate = memberRepository.findLoginAuthenticateByEmail(email);
+        return optionalAuthenticate.orElseThrow(MemberNotFoundException::new);
+    }
+
+    public LoginAuthenticate getLoginAuthenticateByNickname(String nickname) {
+        Optional<LoginAuthenticate> optionalAuthenticate = memberRepository.findLoginAuthenticateByNickname(nickname);
+        return optionalAuthenticate.orElseThrow(MemberNotFoundException::new);
+    }
+
+    public Member getMemberReferenceByContext() {
+        Long id = getMemberIdByContext();
+        return memberRepository.getReferenceById(id);
+    }
+
+    private Long getMemberIdByContext() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        String id = authentication.getName();
+        if (StringUtils.hasText(id) && id.matches("\\d+")) {
+            return (Long) authentication.getPrincipal();
+        }
+
+        throw new MemberNotFoundException();
+    }
+
+    private void validatePassword(String loginPassword, String password) {
+        if (!passwordEncoder.matches(loginPassword, password)) {
+            throw new MemberNotFoundException();
+        }
+    }
+
+    private void checkEmailDuplication(String email) {
+        boolean isExists = memberRepository.existsByEmail(email);
+
+        if (isExists) {
+            throw new EmailDuplicatedException();
+        }
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringApplyController.java
@@ -1,0 +1,30 @@
+package com.dongsoop.dongsoop.tutoring.controller;
+
+import com.dongsoop.dongsoop.tutoring.dto.ApplyTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.service.TutoringApplyService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tutoring-apply")
+@RequiredArgsConstructor
+public class TutoringApplyController {
+
+    private final TutoringApplyService tutoringApplyService;
+
+    @PostMapping
+    public ResponseEntity<Void> applyTutoringBoard(@RequestBody ApplyTutoringBoardRequest applyTutoringBoardRequest) {
+        Long tutoringBoardId = applyTutoringBoardRequest.getTutoringBoardId();
+        tutoringApplyService.apply(tutoringBoardId);
+
+        URI uri = URI.create("/tutoring-board/" + tutoringBoardId);
+
+        return ResponseEntity.created(uri)
+                .build();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/tutoring")
+@RequestMapping("/tutoring-board")
 @RequiredArgsConstructor
 public class TutoringBoardController {
 
@@ -44,7 +44,7 @@ public class TutoringBoardController {
     @PostMapping
     public ResponseEntity<Void> createTutoringBoard(@Valid @RequestBody CreateTutoringBoardRequest request) {
         TutoringBoard createdBoard = tutoringBoardService.create(request);
-        URI uri = URI.create("/tutoring/" + createdBoard.getId());
+        URI uri = URI.create("/tutoring-board/" + createdBoard.getId());
 
         return ResponseEntity.created(uri)
                 .build();

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -8,8 +8,8 @@ import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,9 +27,9 @@ public class TutoringBoardController {
     private final TutoringBoardService tutoringBoardService;
 
     @GetMapping("/department/{departmentType}")
-    public ResponseEntity<Page<TutoringBoardOverview>> getTutoringBoardOverviews(
+    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviews(
             @PathVariable("departmentType") DepartmentType departmentType, Pageable pageable) {
-        Page<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType,
+        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType,
                 pageable);
         return ResponseEntity.ok(tutoringBoardList);
     }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -37,8 +37,7 @@ public class TutoringBoardController {
     @GetMapping("/{tutoringBoardId}")
     public ResponseEntity<TutoringBoardDetails> getTutoringBoard(
             @PathVariable("tutoringBoardId") Long tutoringBoardId) {
-        tutoringBoardService.getTutoringBoardById(tutoringBoardId);
-        TutoringBoardDetails tutoringBoard = tutoringBoardService.getTutoringBoardById(tutoringBoardId);
+        TutoringBoardDetails tutoringBoard = tutoringBoardService.getTutoringBoardDetailsById(tutoringBoardId);
         return ResponseEntity.ok(tutoringBoard);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -5,8 +5,9 @@ import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,9 +24,9 @@ public class TutoringBoardController {
     private final TutoringBoardService tutoringBoardService;
 
     @GetMapping("/{departmentType}")
-    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviews(
-            @PathVariable DepartmentType departmentType) {
-        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getAllTutoringBoard(departmentType);
+    public ResponseEntity<Page<TutoringBoardOverview>> getTutoringBoardOverviews(
+            @PathVariable("departmentType") DepartmentType departmentType, Pageable pageable) {
+        Page<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType, pageable);
         return ResponseEntity.ok(tutoringBoardList);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -3,11 +3,13 @@ package com.dongsoop.dongsoop.tutoring.controller;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,15 +28,17 @@ public class TutoringBoardController {
     @GetMapping("/{departmentType}")
     public ResponseEntity<Page<TutoringBoardOverview>> getTutoringBoardOverviews(
             @PathVariable("departmentType") DepartmentType departmentType, Pageable pageable) {
-        Page<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType, pageable);
+        Page<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType,
+                pageable);
         return ResponseEntity.ok(tutoringBoardList);
     }
 
     @PostMapping
     public ResponseEntity<Void> createTutoringBoard(@Valid @RequestBody CreateTutoringBoardRequest request) {
-        tutoringBoardService.create(request);
+        TutoringBoard createdBoard = tutoringBoardService.create(request);
+        URI uri = URI.create("/tutoring/" + createdBoard.getId());
 
-        return ResponseEntity.ok()
+        return ResponseEntity.created(uri)
                 .build();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -1,0 +1,39 @@
+package com.dongsoop.dongsoop.tutoring.controller;
+
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tutoring")
+@RequiredArgsConstructor
+public class TutoringBoardController {
+
+    private final TutoringBoardService tutoringBoardService;
+
+    @GetMapping("/{departmentType}")
+    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviews(
+            @PathVariable DepartmentType departmentType) {
+        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getAllTutoringBoard(departmentType);
+        return ResponseEntity.ok(tutoringBoardList);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createTutoringBoard(@Valid @RequestBody CreateTutoringBoardRequest request) {
+        tutoringBoardService.create(request);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/controller/TutoringBoardController.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.tutoring.controller;
 
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
@@ -25,12 +26,20 @@ public class TutoringBoardController {
 
     private final TutoringBoardService tutoringBoardService;
 
-    @GetMapping("/{departmentType}")
+    @GetMapping("/department/{departmentType}")
     public ResponseEntity<Page<TutoringBoardOverview>> getTutoringBoardOverviews(
             @PathVariable("departmentType") DepartmentType departmentType, Pageable pageable) {
         Page<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getTutoringBoardByPage(departmentType,
                 pageable);
         return ResponseEntity.ok(tutoringBoardList);
+    }
+
+    @GetMapping("/{tutoringBoardId}")
+    public ResponseEntity<TutoringBoardDetails> getTutoringBoard(
+            @PathVariable("tutoringBoardId") Long tutoringBoardId) {
+        tutoringBoardService.getTutoringBoardById(tutoringBoardId);
+        TutoringBoardDetails tutoringBoard = tutoringBoardService.getTutoringBoardById(tutoringBoardId);
+        return ResponseEntity.ok(tutoringBoard);
     }
 
     @PostMapping

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/ApplyTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/ApplyTutoringBoardRequest.java
@@ -1,0 +1,13 @@
+package com.dongsoop.dongsoop.tutoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplyTutoringBoardRequest {
+
+    private Long tutoringBoardId;
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -6,11 +6,15 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateTutoringBoardRequest {
 
     @NotBlank

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -20,20 +20,20 @@ public class CreateTutoringBoardRequest {
     private String content;
 
     @NotBlank
-    String tags;
+    private String tags;
 
     @NotNull
     @Min(1)
-    Integer recruitmentCapacity;
+    private Integer recruitmentCapacity;
 
     @NotNull
     @TodayOrFuture
-    LocalDateTime startAt;
+    private LocalDateTime startAt;
 
     @NotNull
     @TodayOrFuture
-    LocalDateTime endAt;
+    private LocalDateTime endAt;
 
     @NotNull
-    DepartmentType departmentType;
+    private DepartmentType departmentType;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -1,6 +1,8 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
 import com.dongsoop.dongsoop.date.EndAtAfterStartAt;
+import com.dongsoop.dongsoop.date.MaxDuration;
+import com.dongsoop.dongsoop.date.MinDuration;
 import com.dongsoop.dongsoop.date.TodayOrFuture;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import jakarta.validation.constraints.Min;
@@ -16,6 +18,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@MaxDuration // 최대 4주 (28일)
+@MinDuration // 최소 하루
 @EndAtAfterStartAt
 public class CreateTutoringBoardRequest {
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
+import com.dongsoop.dongsoop.date.EndAtAfterStartAt;
 import com.dongsoop.dongsoop.date.TodayOrFuture;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import jakarta.validation.constraints.Min;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EndAtAfterStartAt
 public class CreateTutoringBoardRequest {
 
     @NotBlank

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
 import com.dongsoop.dongsoop.date.EndAtAfterStartAt;
+import com.dongsoop.dongsoop.date.MaxDate;
 import com.dongsoop.dongsoop.date.MaxDuration;
 import com.dongsoop.dongsoop.date.MinDuration;
 import com.dongsoop.dongsoop.date.TodayOrFuture;
@@ -37,6 +38,7 @@ public class CreateTutoringBoardRequest {
     private Integer recruitmentCapacity;
 
     @NotNull
+    @MaxDate(month = 3)
     @TodayOrFuture
     private LocalDateTime startAt;
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -40,4 +40,10 @@ public class CreateTutoringBoardRequest {
 
     @NotNull
     private DepartmentType departmentType;
+
+    public void validateEndAt() {
+        if (startAt.isAfter(endAt)) {
+            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -35,7 +35,7 @@ public class CreateTutoringBoardRequest {
 
     @NotNull
     @Min(1)
-    private Integer recruitmentCapacity;
+    private Integer capacity;
 
     @NotNull
     @MaxDate(month = 3)

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -48,10 +48,4 @@ public class CreateTutoringBoardRequest {
 
     @NotNull
     private DepartmentType departmentType;
-
-    public void validateEndAt() {
-        if (startAt.isAfter(endAt)) {
-            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다.");
-        }
-    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -1,0 +1,39 @@
+package com.dongsoop.dongsoop.tutoring.dto;
+
+import com.dongsoop.dongsoop.date.TodayOrFuture;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateTutoringBoardRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    @NotBlank
+    String tags;
+
+    @NotNull
+    @Min(1)
+    Integer recruitmentCapacity;
+
+    @NotNull
+    @TodayOrFuture
+    LocalDateTime startAt;
+
+    @NotNull
+    @TodayOrFuture
+    LocalDateTime endAt;
+
+    @NotNull
+    DepartmentType departmentType;
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
@@ -1,29 +1,38 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
+import com.dongsoop.dongsoop.board.BoardDate;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public interface TutoringBoardDetails {
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TutoringBoardDetails {
 
-    Long getId();
+    private Long id;
 
-    String getTitle();
+    private String title;
 
-    String getContent();
+    private String content;
 
-    String getTags();
+    private String tags;
 
-    Integer getCapacity();
+    private Integer capacity;
 
-    LocalDateTime getStartAt();
+    private LocalDateTime startAt;
 
-    LocalDateTime getEndAt();
+    private LocalDateTime endAt;
 
-    DepartmentType getDepartmentType();
+    private DepartmentType departmentType;
 
-    String getAuthor();
+    private String author;
 
-    LocalDateTime getCreatedAt();
+    private LocalDateTime createdAt;
 
-    LocalDateTime getUpdatedAt();
+    private LocalDateTime updatedAt;
+
+    private BoardDate boardDate;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
@@ -1,0 +1,29 @@
+package com.dongsoop.dongsoop.tutoring.dto;
+
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import java.time.LocalDateTime;
+
+public interface TutoringBoardDetails {
+
+    Long getId();
+
+    String getTitle();
+
+    String getContent();
+
+    String getTags();
+
+    Integer getRecruitmentCapacity();
+
+    LocalDateTime getStartAt();
+
+    LocalDateTime getEndAt();
+
+    DepartmentType getDepartmentType();
+
+    String getAuthor();
+
+    LocalDateTime getCreatedAt();
+
+    LocalDateTime getUpdatedAt();
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
@@ -13,7 +13,7 @@ public interface TutoringBoardDetails {
 
     String getTags();
 
-    Integer getRecruitmentCapacity();
+    Integer getCapacity();
 
     LocalDateTime getStartAt();
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
-import com.dongsoop.dongsoop.board.BoardDate;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -34,5 +33,5 @@ public class TutoringBoardDetails {
 
     private LocalDateTime updatedAt;
 
-    private BoardDate boardDate;
+    private Integer volunteer;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -1,22 +1,16 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class TutoringBoardOverview {
+public interface TutoringBoardOverview {
 
-    private Integer recruitmentCapacity;
+    Integer getCapacity();
 
-    private LocalDateTime recruitmentDeadline;
+    LocalDateTime getEndAt();
 
-    private String title;
+    String getTitle();
 
-    private String content;
+    String getContent();
 
-    private String tags;
+    String getTags();
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -1,0 +1,22 @@
+package com.dongsoop.dongsoop.tutoring.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TutoringBoardOverview {
+
+    private Integer recruitmentCapacity;
+
+    private LocalDateTime recruitmentDeadline;
+
+    private String title;
+
+    private String content;
+
+    private String tags;
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -10,7 +10,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TutoringBoardOverview {
 
+    private Long id;
+
     private Integer capacity;
+
+    private Integer volunteer;
 
     private LocalDateTime endAt;
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -1,16 +1,24 @@
 package com.dongsoop.dongsoop.tutoring.dto;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public interface TutoringBoardOverview {
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TutoringBoardOverview {
 
-    Integer getCapacity();
+    private Integer capacity;
 
-    LocalDateTime getEndAt();
+    private LocalDateTime endAt;
 
-    String getTitle();
+    private String title;
 
-    String getContent();
+    private String content;
 
-    String getTags();
+    private String tags;
+
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringApplication.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringApplication.java
@@ -1,0 +1,38 @@
+package com.dongsoop.dongsoop.tutoring.entity;
+
+import com.dongsoop.dongsoop.common.BaseEntity;
+import com.dongsoop.dongsoop.member.entity.Member;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@SQLRestriction("is_deleted = false")
+public class TutoringApplication extends BaseEntity {
+
+    @EmbeddedId
+    private TutoringApplicationKey id;
+
+    @Embeddable
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TutoringApplicationKey {
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(nullable = false, name = "tutoring_board_id", updatable = false)
+        private TutoringBoard tutoringBoard;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(nullable = false, name = "member_id", updatable = false)
+        private Member member;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringBoard.java
@@ -14,11 +14,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @SuperBuilder
 @NoArgsConstructor
 @SequenceGenerator(name = "tutoring_board_sequence_generator")
+@SQLRestriction("is_deleted = false")
 public class TutoringBoard extends RecruitmentBoard {
 
     @Id

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/entity/TutoringBoard.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -21,6 +22,7 @@ import lombok.experimental.SuperBuilder;
 public class TutoringBoard extends RecruitmentBoard {
 
     @Id
+    @Getter
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tutoring_board_sequence_generator")
     private Long id;
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringApplicationRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.dongsoop.dongsoop.tutoring.repository;
+
+import com.dongsoop.dongsoop.tutoring.entity.TutoringApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TutoringApplicationRepository extends JpaRepository<TutoringApplication, TutoringApplication.TutoringApplicationKey> {
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -26,7 +26,7 @@ public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Lo
             + "b.content as content, "
             + "b.startAt as startAt, "
             + "b.endAt as endAt, "
-            + "b.recruitmentCapacity as recruitmentCapacity, "
+            + "b.capacity as capacity, "
             + "b.tags as tags, "
             + "b.author.nickname as author, "
             + "b.department.id as departmentType, "

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -1,13 +1,15 @@
 package com.dongsoop.dongsoop.tutoring.repository;
 
 import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Long> {
 
@@ -15,5 +17,22 @@ public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Lo
             + "FROM TutoringBoard b "
             + "WHERE b.department = :recruitmentDepartment AND "
             + " b.endAt > CURRENT_TIMESTAMP")
-    Page<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment, Pageable Pageable);
+    Page<TutoringBoardOverview> findTutoringBoardOverviewsByPage(
+            @Param("recruitmentDepartment") Department recruitmentDepartment, Pageable Pageable);
+
+    @Query("SELECT "
+            + "b.id as id, "
+            + "b.title as title, "
+            + "b.content as content, "
+            + "b.startAt as startAt, "
+            + "b.endAt as endAt, "
+            + "b.recruitmentCapacity as recruitmentCapacity, "
+            + "b.tags as tags, "
+            + "b.author.nickname as author, "
+            + "b.department.id as departmentType, "
+            + "b.boardDate.createdAt as createdAt, "
+            + "b.boardDate.updatedAt as updatedAt "
+            + "FROM TutoringBoard b "
+            + "WHERE b.id = :tutoringBoardId")
+    Optional<TutoringBoardDetails> findInformationById(@Param("tutoringBoardId") Long tutoringBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -4,8 +4,8 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +13,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Long> {
 
-    @Query("SELECT new com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview(b.recruitmentCapacity, b.endAt, b.title, b.content, b.tags) "
+    @Query("SELECT "
+            + "b.capacity as capacity, "
+            + "b.endAt as endAt, "
+            + "b.title as title, "
+            + "b.content as content, "
+            + "b.tags as tags "
             + "FROM TutoringBoard b "
             + "WHERE b.department = :recruitmentDepartment AND "
             + " b.endAt > CURRENT_TIMESTAMP")

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -17,8 +17,8 @@ public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Lo
             + "FROM TutoringBoard b "
             + "WHERE b.department = :recruitmentDepartment AND "
             + " b.endAt > CURRENT_TIMESTAMP")
-    Page<TutoringBoardOverview> findTutoringBoardOverviewsByPage(
-            @Param("recruitmentDepartment") Department recruitmentDepartment, Pageable Pageable);
+    List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(
+            @Param("recruitmentDepartment") Department recruitmentDepartment, Pageable pageable);
 
     @Query("SELECT "
             + "b.id as id, "

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -1,0 +1,17 @@
+package com.dongsoop.dongsoop.tutoring.repository;
+
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Long> {
+
+    @Query("SELECT new com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview(b.recruitmentCapacity, b.endAt, b.title, b.content, b.tags) "
+            + "FROM TutoringBoard b "
+            + "WHERE b.department = :recruitmentDepartment AND "
+            + " b.endAt > CURRENT_TIMESTAMP")
+    List<TutoringBoardOverview> findAllTutoringBoardOverviews(Department recruitmentDepartment);
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -4,6 +4,8 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -13,5 +15,5 @@ public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Lo
             + "FROM TutoringBoard b "
             + "WHERE b.department = :recruitmentDepartment AND "
             + " b.endAt > CURRENT_TIMESTAMP")
-    List<TutoringBoardOverview> findAllTutoringBoardOverviews(Department recruitmentDepartment);
+    Page<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment, Pageable Pageable);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepository.java
@@ -1,43 +1,7 @@
 package com.dongsoop.dongsoop.tutoring.repository;
 
-import com.dongsoop.dongsoop.department.entity.Department;
-import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
-import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Long> {
-
-    @Query("SELECT "
-            + "b.capacity as capacity, "
-            + "b.endAt as endAt, "
-            + "b.title as title, "
-            + "b.content as content, "
-            + "b.tags as tags "
-            + "FROM TutoringBoard b "
-            + "WHERE b.department = :recruitmentDepartment AND "
-            + " b.endAt > CURRENT_TIMESTAMP")
-    List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(
-            @Param("recruitmentDepartment") Department recruitmentDepartment, Pageable pageable);
-
-    @Query("SELECT "
-            + "b.id as id, "
-            + "b.title as title, "
-            + "b.content as content, "
-            + "b.startAt as startAt, "
-            + "b.endAt as endAt, "
-            + "b.capacity as capacity, "
-            + "b.tags as tags, "
-            + "b.author.nickname as author, "
-            + "b.department.id as departmentType, "
-            + "b.boardDate.createdAt as createdAt, "
-            + "b.boardDate.updatedAt as updatedAt "
-            + "FROM TutoringBoard b "
-            + "WHERE b.id = :tutoringBoardId")
-    Optional<TutoringBoardDetails> findInformationById(@Param("tutoringBoardId") Long tutoringBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.dongsoop.dongsoop.tutoring.repository;
+
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+
+public interface TutoringBoardRepositoryCustom {
+
+    List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment,
+                                                                 Pageable pageable);
+
+    Optional<TutoringBoardDetails> findInformationById(Long tutoringBoardId);
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -1,0 +1,63 @@
+package com.dongsoop.dongsoop.tutoring.repository;
+
+import com.dongsoop.dongsoop.common.PageableUtil;
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.QTutoringBoard;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+        private final PageableUtil pageableUtil;
+
+    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment, Pageable pageable) {
+        QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
+
+        return queryFactory.select(Projections.constructor(TutoringBoardOverview.class,
+                        tutoringBoard.capacity,
+                        tutoringBoard.endAt,
+                        tutoringBoard.title,
+                        tutoringBoard.content,
+                        tutoringBoard.tags,
+                        tutoringBoard.boardDate.createdAt))
+                .from(tutoringBoard)
+                .where(tutoringBoard.department.eq(recruitmentDepartment))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort()))
+                .fetch();
+    }
+
+    public Optional<TutoringBoardDetails> findInformationById(Long tutoringBoardId) {
+        QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
+
+        return Optional.ofNullable(
+                queryFactory.select(Projections.constructor(TutoringBoardDetails.class,
+                                tutoringBoard.id,
+                                tutoringBoard.title,
+                                tutoringBoard.content,
+                                tutoringBoard.tags,
+                                tutoringBoard.capacity,
+                                tutoringBoard.startAt,
+                                tutoringBoard.endAt,
+                                tutoringBoard.department.id,
+                                tutoringBoard.author.nickname,
+                                tutoringBoard.boardDate.createdAt.as("createdAt"),
+                                tutoringBoard.boardDate.updatedAt.as("updatedAt")
+                        ))
+                        .from(tutoringBoard)
+                        .where(tutoringBoard.id.eq(tutoringBoardId))
+                        .fetchOne());
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.common.PageableUtil;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.QTutoringApplication;
 import com.dongsoop.dongsoop.tutoring.entity.QTutoringBoard;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,28 +20,35 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
 
     private final JPAQueryFactory queryFactory;
 
-        private final PageableUtil pageableUtil;
+    private final PageableUtil pageableUtil;
 
     public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment, Pageable pageable) {
         QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
+        QTutoringApplication tutoringApplication = QTutoringApplication.tutoringApplication;
 
         return queryFactory.select(Projections.constructor(TutoringBoardOverview.class,
+                        tutoringBoard.id,
                         tutoringBoard.capacity,
+                        tutoringApplication.id.member.count().intValue(),
                         tutoringBoard.endAt,
                         tutoringBoard.title,
                         tutoringBoard.content,
                         tutoringBoard.tags,
                         tutoringBoard.boardDate.createdAt))
                 .from(tutoringBoard)
+                .leftJoin(tutoringApplication)
+                .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))
                 .where(tutoringBoard.department.eq(recruitmentDepartment))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .groupBy(tutoringBoard.id)
                 .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort()))
                 .fetch();
     }
 
     public Optional<TutoringBoardDetails> findInformationById(Long tutoringBoardId) {
         QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
+        QTutoringApplication tutoringApplication = QTutoringApplication.tutoringApplication;
 
         return Optional.ofNullable(
                 queryFactory.select(Projections.constructor(TutoringBoardDetails.class,
@@ -54,10 +62,14 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                                 tutoringBoard.department.id,
                                 tutoringBoard.author.nickname,
                                 tutoringBoard.boardDate.createdAt.as("createdAt"),
-                                tutoringBoard.boardDate.updatedAt.as("updatedAt")
+                                tutoringBoard.boardDate.updatedAt.as("updatedAt"),
+                                tutoringApplication.id.member.count().intValue()
                         ))
                         .from(tutoringBoard)
+                        .leftJoin(tutoringApplication)
+                        .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))
                         .where(tutoringBoard.id.eq(tutoringBoardId))
+                        .groupBy(tutoringBoard.id, tutoringBoard.author.nickname)
                         .fetchOne());
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringApplyService.java
@@ -1,0 +1,6 @@
+package com.dongsoop.dongsoop.tutoring.service;
+
+public interface TutoringApplyService {
+
+    void apply(Long tutoringBoardId);
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringApplyServiceImpl.java
@@ -1,0 +1,35 @@
+package com.dongsoop.dongsoop.tutoring.service;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringApplication;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringApplication.TutoringApplicationKey;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringApplicationRepository;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TutoringApplyServiceImpl implements TutoringApplyService{
+
+    private final MemberService memberService;
+
+    private final TutoringApplicationRepository tutoringApplicationRepository;
+
+    private final TutoringBoardRepository tutoringBoardRepository;
+
+    public void apply(Long tutoringBoardId) {
+        Member member = memberService.getMemberReferenceByContext();
+        TutoringBoard referenceById = tutoringBoardRepository.getReferenceById(tutoringBoardId);
+
+        TutoringApplicationKey key = new TutoringApplicationKey(referenceById, member);
+
+        TutoringApplication tutoringApplication = TutoringApplication.builder()
+                .id(key)
+                .build();
+
+        tutoringApplicationRepository.save(tutoringApplication);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -3,11 +3,12 @@ package com.dongsoop.dongsoop.tutoring.service;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TutoringBoardService {
 
-    List<TutoringBoardOverview> getAllTutoringBoard(DepartmentType departmentType);
+    Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable);
 
     void create(CreateTutoringBoardRequest request);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.tutoring.service;
 
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import org.springframework.data.domain.Page;
@@ -12,4 +13,6 @@ public interface TutoringBoardService {
     Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable);
 
     TutoringBoard create(CreateTutoringBoardRequest request);
+
+    TutoringBoardDetails getTutoringBoardById(Long tutoringBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -5,12 +5,12 @@ import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
-import org.springframework.data.domain.Page;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface TutoringBoardService {
 
-    Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable);
+    List<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable);
 
     TutoringBoard create(CreateTutoringBoardRequest request);
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -14,5 +14,5 @@ public interface TutoringBoardService {
 
     TutoringBoard create(CreateTutoringBoardRequest request);
 
-    TutoringBoardDetails getTutoringBoardById(Long tutoringBoardId);
+    TutoringBoardDetails getTutoringBoardDetailsById(Long tutoringBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.tutoring.service;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +11,5 @@ public interface TutoringBoardService {
 
     Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable);
 
-    void create(CreateTutoringBoardRequest request);
+    TutoringBoard create(CreateTutoringBoardRequest request);
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardService.java
@@ -1,0 +1,13 @@
+package com.dongsoop.dongsoop.tutoring.service;
+
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import java.util.List;
+
+public interface TutoringBoardService {
+
+    List<TutoringBoardOverview> getAllTutoringBoard(DepartmentType departmentType);
+
+    void create(CreateTutoringBoardRequest request);
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -5,9 +5,11 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
 import com.dongsoop.dongsoop.exception.domain.department.DepartmentNotFoundException;
+import com.dongsoop.dongsoop.exception.domain.tutoring.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
@@ -38,6 +40,12 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
     public TutoringBoard create(CreateTutoringBoardRequest request) {
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
         return tutoringBoardRepository.save(tutoringBoard);
+    }
+
+    public TutoringBoardDetails getTutoringBoardById(Long tutoringBoardId) {
+        Optional<TutoringBoardDetails> optionalTutoringBoardInformation = tutoringBoardRepository.findInformationById(
+                tutoringBoardId);
+        return optionalTutoringBoardInformation.orElseThrow(() -> new TutoringBoardNotFound(tutoringBoardId));
     }
 
     private TutoringBoard transformToTutoringBoard(CreateTutoringBoardRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -38,6 +38,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
     }
 
     public TutoringBoard create(CreateTutoringBoardRequest request) {
+        request.validateEndAt();
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
         return tutoringBoardRepository.save(tutoringBoard);
     }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -1,0 +1,60 @@
+package com.dongsoop.dongsoop.tutoring.service;
+
+import com.dongsoop.dongsoop.board.BoardDate;
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
+import com.dongsoop.dongsoop.exception.domain.department.DepartmentNotFoundException;
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TutoringBoardServiceImpl implements TutoringBoardService {
+
+    private final TutoringBoardRepository tutoringBoardRepository;
+
+    private final DepartmentRepository departmentRepository;
+
+    private final MemberService memberService;
+
+    public List<TutoringBoardOverview> getAllTutoringBoard(DepartmentType departmentType) {
+        Optional<Department> optionalRecruitmentDepartment = departmentRepository.findById(departmentType);
+        Department recruitmentDepartment = optionalRecruitmentDepartment.orElseThrow(
+                () -> new DepartmentNotFoundException(departmentType));
+
+        return tutoringBoardRepository.findAllTutoringBoardOverviews(recruitmentDepartment);
+    }
+
+    public void create(CreateTutoringBoardRequest request) {
+        TutoringBoard tutoringBoard = transformToTutoringBoard(request);
+        tutoringBoardRepository.save(tutoringBoard);
+    }
+
+    private TutoringBoard transformToTutoringBoard(CreateTutoringBoardRequest request) {
+        Member memberReference = memberService.getMemberReferenceByContext();
+
+        DepartmentType departmentType = request.getDepartmentType();
+        Department departmentReference = departmentRepository.getReferenceById(departmentType);
+
+        return TutoringBoard.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .author(memberReference)
+                .tags(request.getTags())
+                .department(departmentReference)
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
+                .recruitmentCapacity(request.getRecruitmentCapacity())
+                .boardDate(new BoardDate())
+                .build();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -38,7 +38,6 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
     }
 
     public TutoringBoard create(CreateTutoringBoardRequest request) {
-        request.validateEndAt();
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
         return tutoringBoardRepository.save(tutoringBoard);
     }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -13,6 +13,7 @@ import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,8 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final TutoringBoardRepository tutoringBoardRepository;
 
+    private final TutoringBoardRepositoryCustom tutoringBoardRepositoryCustom;
+
     private final DepartmentRepository departmentRepository;
 
     private final MemberService memberService;
@@ -34,7 +37,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         Department recruitmentDepartment = optionalRecruitmentDepartment.orElseThrow(
                 () -> new DepartmentNotFoundException(departmentType));
 
-        return tutoringBoardRepository.findTutoringBoardOverviewsByPage(recruitmentDepartment, pageable);
+        return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPage(recruitmentDepartment, pageable);
     }
 
     public TutoringBoard create(CreateTutoringBoardRequest request) {
@@ -43,7 +46,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
     }
 
     public TutoringBoardDetails getTutoringBoardDetailsById(Long tutoringBoardId) {
-        return tutoringBoardRepository.findInformationById(tutoringBoardId)
+        return tutoringBoardRepositoryCustom.findInformationById(tutoringBoardId)
                 .orElseThrow(() -> new TutoringBoardNotFound(tutoringBoardId));
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -14,6 +14,8 @@ import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,12 +28,12 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final MemberService memberService;
 
-    public List<TutoringBoardOverview> getAllTutoringBoard(DepartmentType departmentType) {
+    public Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable) {
         Optional<Department> optionalRecruitmentDepartment = departmentRepository.findById(departmentType);
         Department recruitmentDepartment = optionalRecruitmentDepartment.orElseThrow(
                 () -> new DepartmentNotFoundException(departmentType));
 
-        return tutoringBoardRepository.findAllTutoringBoardOverviews(recruitmentDepartment);
+        return tutoringBoardRepository.findTutoringBoardOverviewsByPage(recruitmentDepartment, pageable);
     }
 
     public void create(CreateTutoringBoardRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -62,7 +62,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 .department(departmentReference)
                 .startAt(request.getStartAt())
                 .endAt(request.getEndAt())
-                .recruitmentCapacity(request.getRecruitmentCapacity())
+                .capacity(request.getRecruitmentCapacity())
                 .boardDate(new BoardDate())
                 .build();
     }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -13,9 +13,9 @@ import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +29,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final MemberService memberService;
 
-    public Page<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable) {
+    public List<TutoringBoardOverview> getTutoringBoardByPage(DepartmentType departmentType, Pageable pageable) {
         Optional<Department> optionalRecruitmentDepartment = departmentRepository.findById(departmentType);
         Department recruitmentDepartment = optionalRecruitmentDepartment.orElseThrow(
                 () -> new DepartmentNotFoundException(departmentType));

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -62,7 +62,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 .department(departmentReference)
                 .startAt(request.getStartAt())
                 .endAt(request.getEndAt())
-                .capacity(request.getRecruitmentCapacity())
+                .capacity(request.getCapacity())
                 .boardDate(new BoardDate())
                 .build();
     }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -42,10 +42,9 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         return tutoringBoardRepository.save(tutoringBoard);
     }
 
-    public TutoringBoardDetails getTutoringBoardById(Long tutoringBoardId) {
-        Optional<TutoringBoardDetails> optionalTutoringBoardInformation = tutoringBoardRepository.findInformationById(
-                tutoringBoardId);
-        return optionalTutoringBoardInformation.orElseThrow(() -> new TutoringBoardNotFound(tutoringBoardId));
+    public TutoringBoardDetails getTutoringBoardDetailsById(Long tutoringBoardId) {
+        return tutoringBoardRepository.findInformationById(tutoringBoardId)
+                .orElseThrow(() -> new TutoringBoardNotFound(tutoringBoardId));
     }
 
     private TutoringBoard transformToTutoringBoard(CreateTutoringBoardRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -11,7 +11,6 @@ import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,9 +35,9 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         return tutoringBoardRepository.findTutoringBoardOverviewsByPage(recruitmentDepartment, pageable);
     }
 
-    public void create(CreateTutoringBoardRequest request) {
+    public TutoringBoard create(CreateTutoringBoardRequest request) {
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
-        tutoringBoardRepository.save(tutoringBoard);
+        return tutoringBoardRepository.save(tutoringBoard);
     }
 
     private TutoringBoard transformToTutoringBoard(CreateTutoringBoardRequest request) {

--- a/src/test/java/com/dongsoop/dongsoop/notice/NoticeCrawlingTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/notice/NoticeCrawlingTest.java
@@ -3,15 +3,19 @@ package com.dongsoop.dongsoop.notice;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
 import com.dongsoop.dongsoop.notice.entity.Notice;
 import com.dongsoop.dongsoop.notice.entity.Notice.NoticeKey;
 import com.dongsoop.dongsoop.notice.repository.NoticeDetailsRepository;
 import com.dongsoop.dongsoop.notice.repository.NoticeRepository;
 import com.dongsoop.dongsoop.notice.service.NoticeScheduler;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -25,16 +29,15 @@ import org.springframework.util.ReflectionUtils;
 @SpringBootTest
 class NoticeCrawlingTest {
 
+    static final Integer MIN_NUMBER_OF_INVOCATIONS = 1;
     @Autowired
     NoticeScheduler noticeScheduler;
-
     @MockitoBean
     NoticeRepository noticeRepository;
-
     @MockitoBean
     NoticeDetailsRepository noticeDetailsRepository;
-
-    static final Integer MIN_NUMBER_OF_INVOCATIONS = 1;
+    @MockitoBean
+    DepartmentRepository departmentRepository;
 
     @AfterEach
     void cleanup() {
@@ -44,6 +47,13 @@ class NoticeCrawlingTest {
 
     @Test
     void get_at_least_one_notice_from_each_department() throws NoSuchFieldException, SecurityException {
+        // given
+        List<Department> departmentList = getDepartmentList();
+
+        when(departmentRepository.findAll())
+                .thenReturn(departmentList);
+
+        // when
         noticeScheduler.scheduled();
 
         Field idField = Notice.class.getDeclaredField("id");
@@ -52,8 +62,42 @@ class NoticeCrawlingTest {
         idField.setAccessible(true);
         departmentField.setAccessible(true);
 
+        // then
         verify(noticeRepository, atLeast(MIN_NUMBER_OF_INVOCATIONS)).saveAll(
                 argThat(notices -> validateSavedNoticeByDepartment(notices, idField, departmentField)));
+    }
+
+    List<Department> getDepartmentList() {
+        List<Department> departmentList = new ArrayList<>();
+
+        departmentList.add(new Department(DepartmentType.DEPT_1001, "미소속", "/dmu/4904/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_2001, "컴퓨터소프트웨어공학과", "/dmu/4580/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_2002, "인공지능소프트웨어학과", "/dmu/4593/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_2003, "웹응용소프트웨어공학과", "/dmu/4568/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_3001, "기계공학과", "/dmu/4461/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_3002, "기계설계공학과", "/dmu/4474/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_4001, "자동화공학과", "/dmu/4487/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_4002, "로봇소프트웨어과", "/dmu/4502/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_5001, "전기공학과", "/dmu/4518/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_5002, "반도체전자공학과", "/dmu/4530/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_5003, "정보통신공학과", "/dmu/4543/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_5004, "소방안전관리과", "/dmu/4557/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6001, "생명화학공학과", "/dmu/4605/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6002, "바이오융합공학과", "/dmu/4617/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6003, "건축과", "/dmu/4629/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6004, "실내건축디자인과", "/dmu/4643/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6005, "시각디자인과", "/dmu/4654/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_6006, "AR·VR콘텐츠디자인과", "/dmu/4666/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7001, "경영학과", "/dmu/4677/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7002, "세무회계학과", "/dmu/4687/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7003, "유통마케팅학과", "/dmu/4697/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7004, "호텔관광학과", "/dmu/4708/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7005, "경영정보학과", "/dmu/4719/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_7006, "빅데이터경영과", "/dmu/4729/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_8001, "자유전공학과", "/dmu/4739/subview.do"));
+        departmentList.add(new Department(DepartmentType.DEPT_9001, "교양과", "/dmu/4747/subview.do"));
+
+        return departmentList;
     }
 
     boolean validateSavedNoticeByDepartment(Iterable<Notice> notices, Field idField, Field departmentField) {

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -54,7 +54,7 @@ class TutoringBoardCreateTest {
                 .title(VALID_TITLE)
                 .content(VALID_CONTENT)
                 .tags(VALID_TAGS)
-                .recruitmentCapacity(VALID_RECRUITMENT_CAPACITY)
+                .capacity(VALID_RECRUITMENT_CAPACITY)
                 .startAt(VALID_START_AT)
                 .endAt(VALID_END_AT)
                 .departmentType(VALID_DEPARTMENT_TYPE)

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -89,7 +89,7 @@ class TutoringBoardCreateTest {
                 .title(VALID_TITLE)
                 .content(VALID_CONTENT)
                 .tags(VALID_TAGS)
-                .recruitmentCapacity(VALID_RECRUITMENT_CAPACITY)
+                .capacity(VALID_RECRUITMENT_CAPACITY)
                 .startAt(VALID_START_AT)
                 .endAt(VALID_END_AT)
                 .department(department)

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -1,0 +1,104 @@
+package com.dongsoop.dongsoop.tutoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import com.dongsoop.dongsoop.tutoring.service.TutoringBoardServiceImpl;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TutoringBoardCreateTest {
+
+    private final String VALID_TITLE = "This is a test title";
+    private final String VALID_CONTENT = "This is a test content";
+    private final String VALID_TAGS = "tag1, tag2";
+    private final Integer VALID_RECRUITMENT_CAPACITY = 5;
+    private final DepartmentType VALID_DEPARTMENT_TYPE = DepartmentType.DEPT_2001;
+    private final LocalDateTime VALID_START_AT = LocalDateTime.of(2099, 1, 1, 0, 0);
+    private final LocalDateTime VALID_END_AT = LocalDateTime.of(2099, 12, 31, 23, 59);
+
+    @InjectMocks
+    private TutoringBoardServiceImpl tutoringBoardService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private TutoringBoardRepository tutoringBoardRepository;
+
+    @Mock
+    private DepartmentRepository departmentRepository;
+
+    private CreateTutoringBoardRequest request;
+
+    @BeforeEach
+    void setUp() {
+        this.request = new CreateTutoringBoardRequest();
+        this.request.setTitle(VALID_TITLE);
+        this.request.setContent(VALID_CONTENT);
+        this.request.setTags(VALID_TAGS);
+        this.request.setRecruitmentCapacity(VALID_RECRUITMENT_CAPACITY);
+        this.request.setStartAt(VALID_START_AT);
+        this.request.setEndAt(VALID_END_AT);
+        this.request.setDepartmentType(VALID_DEPARTMENT_TYPE);
+    }
+
+    @Test
+    void create_WithValidInput_ShouldPersistCorrectly() {
+        // given
+        when(memberService.getMemberReferenceByContext())
+                .thenReturn(
+                        Member.builder()
+                                .id(1L)
+                                .build());
+
+        when(tutoringBoardRepository.save(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(departmentRepository.getReferenceById(VALID_DEPARTMENT_TYPE))
+                .thenReturn(new Department(VALID_DEPARTMENT_TYPE, null, null));
+
+        // when
+        tutoringBoardService.create(this.request);
+
+        // then
+        ArgumentCaptor<TutoringBoard> captor = ArgumentCaptor.forClass(TutoringBoard.class);
+        verify(tutoringBoardRepository).save(captor.capture());
+        TutoringBoard board = captor.getValue();
+
+        Department department = new Department(VALID_DEPARTMENT_TYPE, null, null);
+        TutoringBoard compareBoard = TutoringBoard.builder()
+                .title(VALID_TITLE)
+                .content(VALID_CONTENT)
+                .tags(VALID_TAGS)
+                .recruitmentCapacity(VALID_RECRUITMENT_CAPACITY)
+                .startAt(VALID_START_AT)
+                .endAt(VALID_END_AT)
+                .department(department)
+                .author(Member.builder().id(1L).build())
+                .build();
+
+        assertThat(board)
+                .usingRecursiveComparison()
+                .ignoringExpectedNullFields()
+                .ignoringFields("id", "boardDate.createdAt", "boardDate.updatedAt")
+                .isEqualTo(compareBoard);
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -50,14 +50,15 @@ class TutoringBoardCreateTest {
 
     @BeforeEach
     void setUp() {
-        this.request = new CreateTutoringBoardRequest();
-        this.request.setTitle(VALID_TITLE);
-        this.request.setContent(VALID_CONTENT);
-        this.request.setTags(VALID_TAGS);
-        this.request.setRecruitmentCapacity(VALID_RECRUITMENT_CAPACITY);
-        this.request.setStartAt(VALID_START_AT);
-        this.request.setEndAt(VALID_END_AT);
-        this.request.setDepartmentType(VALID_DEPARTMENT_TYPE);
+        request = CreateTutoringBoardRequest.builder()
+                .title(VALID_TITLE)
+                .content(VALID_CONTENT)
+                .tags(VALID_TAGS)
+                .recruitmentCapacity(VALID_RECRUITMENT_CAPACITY)
+                .startAt(VALID_START_AT)
+                .endAt(VALID_END_AT)
+                .departmentType(VALID_DEPARTMENT_TYPE)
+                .build();
     }
 
     @Test

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
@@ -1,0 +1,274 @@
+package com.dongsoop.dongsoop.tutoring;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
+import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.tutoring.controller.TutoringBoardController;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.tutoring.repository.TutoringBoardRepository;
+import com.dongsoop.dongsoop.tutoring.service.TutoringBoardService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@WebMvcTest(controllers = TutoringBoardController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TutoringBoardRecruitDateTest {
+
+    private static LocalDateTime standardDateTime;
+
+    @MockitoBean
+    private TutoringBoardRepository tutoringBoardRepository;
+
+    @MockitoBean
+    private DepartmentRepository departmentRepository;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TutoringBoardService tutoringBoardService;
+
+    @MockitoBean
+    private JwtFilter jwtFilter;
+
+    @BeforeAll
+    static void setUp() {
+        standardDateTime = LocalDate.now()
+                .atStartOfDay()
+                .plusDays(1);
+    }
+
+    @BeforeEach
+    void setUpEach() {
+        TutoringBoard createdBoard = TutoringBoard.builder()
+                .id(1L)
+                .build();
+
+        when(tutoringBoardService.create(any(CreateTutoringBoardRequest.class)))
+                .thenReturn(createdBoard);
+    }
+
+    @Test
+    @DisplayName("모집 시작 날짜가 종료 날짜보다 과거일 경우 예외를 던진다")
+    void startRecruitment_WhenEndAtDateIsBeforeStartAtDate_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        LocalDateTime endAt = standardDateTime; // 기준일 종료
+        LocalDateTime startAt = standardDateTime.plusDays(1); // 기준일보다 하루 뒤 시작
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 시작일이 종료일과 같은 경우 예외를 던진다")
+    void startRecruitment_WhenEndAtIsEqualsStartAt_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        String jsonString = getJsonStringWithDate(standardDateTime, standardDateTime); // 동일한 시작, 종료일
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 시작 시간이 종료 시간보다 이른 경우 예외를 던진다")
+    void startRecruitment_WhenEndAtTimeIsBeforeStartAtTime_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        LocalDateTime endAt = standardDateTime; // 기준일 00시 종료
+        LocalDateTime startAt = endAt.plusHours(1); // 기준일 다음날 01시 시작
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 시작일이 종료일보다 과거인 경우 생성 상태를 반환한다")
+    void startRecruitment_WhenEndAtIsAfterStartAt_ResponseCreated() throws Exception {
+        // given
+        LocalDateTime startAt = standardDateTime; // 기준일 시작
+        LocalDateTime endAt = startAt.plusDays(1); // 기준일 하루 뒤 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        ResultMatcher created = status().isCreated();
+        perform.andExpect(created);
+    }
+
+    @Test
+    @DisplayName("모집 기간이 하루보다 짧은 경우 예외를 던진다")
+    void startRecruitment_WhenDateIsLessThanADay_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        LocalDateTime startAt = standardDateTime.plusHours(14); // 기준일 14시 시작
+        LocalDateTime endAt = startAt.plusHours(23); // 기준일 다음날 13시 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 기간이 4주 보다 긴 경우 예외를 던진다")
+    void startRecruitment_WhenDateIsMoreThanFourWeeks_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        LocalDateTime startAt = standardDateTime; // 오늘 00시 시작
+        LocalDateTime endAt = startAt.plusWeeks(4).plusSeconds(1); // 4주 후 00시 1초 종료 (1초 초과)
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 기간이 하루인 경우 생성 상태를 응답한다")
+    void startRecruitment_WhenDateIsADay_ResponseCreated() throws Exception {
+        // given
+        LocalDateTime startAt = LocalDate.now().atStartOfDay()
+                .plusHours(14); // 오늘 14시 시작
+        LocalDateTime endAt = startAt.plusDays(1); // 다음날 13시 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        ResultMatcher created = status().isCreated();
+        perform.andExpect(created);
+    }
+
+    @Test
+    @DisplayName("모집 기간이 4주인 경우 생성 상태를 응답한다")
+    void startRecruitment_WhenDateIsFourWeeks_ResponseCreated() throws Exception {
+        // given
+        LocalDateTime startAt = LocalDate.now().atStartOfDay(); // 오늘 00시 시작
+        LocalDateTime endAt = startAt.plusWeeks(4); // 4주 후 00시 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        ResultMatcher created = status().isCreated();
+        perform.andExpect(created);
+    }
+
+    @Test
+    @DisplayName("모집 시작일이 3개월이 지난 경우 예외를 던진다")
+    void startRecruitment_WhenStartDateAfterThanThreeMonth_ThrowsMethodArgumentNotValidException() throws Exception {
+        // given
+        LocalDateTime startAt = LocalDateTime.now()
+                .plusMonths(3)
+                .plusDays(1); // 3개월 + 1일 후 시작
+        LocalDateTime endAt = startAt.plusDays(1); // 시작일 다음날 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        testInvalidDates(perform);
+    }
+
+    @Test
+    @DisplayName("모집 시작일이 정확히 3개월만 지난 경우 생성 상태를 응답한다")
+    void startRecruitment_WhenStartDateAfterThreeMonth_ResponseCreated() throws Exception {
+        // given
+        LocalDateTime startAt = LocalDateTime.now()
+                .plusMonths(3); // 3개월 후 시작
+        LocalDateTime endAt = startAt.plusDays(1); // 시작일 다음날 종료
+
+        String jsonString = getJsonStringWithDate(startAt, endAt);
+
+        // when
+        ResultActions perform = requestCreateTutoring(jsonString);
+
+        // then
+        ResultMatcher created = status().isCreated();
+        perform.andExpect(created);
+    }
+
+    String getJsonStringWithDate(LocalDateTime startAt, LocalDateTime endAt) throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("title", "title");
+        json.put("tags", "tags");
+        json.put("recruitmentCapacity", 5);
+        json.put("content", "content");
+        json.put("departmentType", DepartmentType.DEPT_2001);
+        json.put("startAt", startAt.toString());
+        json.put("endAt", endAt.toString());
+
+        return json.toString();
+    }
+
+    void testInvalidDates(ResultActions perform) throws Exception {
+        // then
+        ResultMatcher badRequest = status().isBadRequest();
+        MvcResult result = perform.andExpect(badRequest)
+                .andReturn();
+
+        assertInstanceOf(MethodArgumentNotValidException.class, result.getResolvedException());
+    }
+
+    ResultActions requestCreateTutoring(String jsonTypeString) throws Exception {
+        MockHttpServletRequestBuilder request = post("/tutoring")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonTypeString);
+
+        // when
+        return mockMvc.perform(request);
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
@@ -245,7 +245,7 @@ class TutoringBoardRecruitDateTest {
         JSONObject json = new JSONObject();
         json.put("title", "title");
         json.put("tags", "tags");
-        json.put("recruitmentCapacity", 5);
+        json.put("capacity", 5);
         json.put("content", "content");
         json.put("departmentType", DepartmentType.DEPT_2001);
         json.put("startAt", startAt.toString());

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
@@ -264,7 +264,7 @@ class TutoringBoardRecruitDateTest {
     }
 
     ResultActions requestCreateTutoring(String jsonTypeString) throws Exception {
-        MockHttpServletRequestBuilder request = post("/tutoring")
+        MockHttpServletRequestBuilder request = post("/tutoring-board")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonTypeString);
 

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @WebMvcTest(controllers = TutoringBoardController.class)
 @AutoConfigureMockMvc(addFilters = false)
-public class TutoringBoardStartAtTest {
+class TutoringBoardStartAtTest {
 
     private final JSONObject json = new JSONObject();
 

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -1,0 +1,137 @@
+package com.dongsoop.dongsoop.tutoring;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
+import com.dongsoop.dongsoop.tutoring.controller.TutoringBoardController;
+import com.dongsoop.dongsoop.tutoring.dto.CreateTutoringBoardRequest;
+import com.dongsoop.dongsoop.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.tutoring.service.TutoringBoardServiceImpl;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@WebMvcTest(controllers = TutoringBoardController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class TutoringBoardStartAtTest {
+
+    private final JSONObject json = new JSONObject();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TutoringBoardServiceImpl tutoringBoardService;
+
+    @MockitoBean
+    private JwtFilter jwtFilter;
+
+    @BeforeEach
+    void setUp() throws JSONException {
+        json.put("title", "title");
+        json.put("tags", "tags");
+        json.put("recruitmentCapacity", 5);
+        json.put("content", "content");
+        json.put("departmentType", DepartmentType.DEPT_2001);
+    }
+
+    @Test
+    @DisplayName("모집 게시판 생성 시 모집 시작일이 과거일 경우 예외를 던진다")
+    void startRecruitment_WithPast_ShouldThrowException() throws Exception {
+        // given
+        json.put("startAt", LocalDateTime.of(1999, 10, 1, 0, 0, 0));
+        json.put("endAt", LocalDateTime.of(1999, 10, 30, 23, 59, 59));
+
+        // when
+        MockHttpServletRequestBuilder content = post("/tutoring")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json.toString());
+
+        // then
+        MvcResult result = mockMvc.perform(content)
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        Throwable throwable = result.getResolvedException();
+        assertNotNull(throwable);
+        assertInstanceOf(MethodArgumentNotValidException.class, throwable);
+    }
+
+    @Test
+    @DisplayName("모집 게시판 생성 시 모집 시작일이 오늘일 경우 성공 상태를 반환한다")
+    void startRecruitment_WithToday_ShouldResponseSuccess() throws Exception {
+        // given
+        DepartmentType departmentType = DepartmentType.DEPT_2001;
+        Department department = new Department(departmentType, null, null);
+
+        TutoringBoard tutoringBoard = TutoringBoard.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .tags("tags")
+                .recruitmentCapacity(5)
+                .startAt(LocalDate.now().atStartOfDay())
+                .endAt(LocalDate.now().atStartOfDay())
+                .department(department)
+                .build();
+
+        when(tutoringBoardService.create(any(CreateTutoringBoardRequest.class)))
+                .thenReturn(tutoringBoard);
+
+        json.put("startAt", LocalDate.now().atStartOfDay());
+        json.put("endAt", LocalDate.now().atStartOfDay());
+
+        // when
+        MockHttpServletRequestBuilder httpContent = post("/tutoring")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json.toString());
+
+        // then
+        mockMvc.perform(httpContent)
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("모집 게시판 생성 시 모집 시작일이 null인 경우 예외를 던진다")
+    void startRecruitment_WithNull_ShouldThrowException() throws Exception {
+        // given
+        json.put("startAt", null);
+        json.put("endAt", null);
+
+        // when
+        MockHttpServletRequestBuilder content = post("/tutoring")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json.toString());
+
+        //TODO 정확한 예외 클래스 검증
+
+        // then
+        MvcResult result = mockMvc.perform(content)
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        Throwable throwable = result.getResolvedException();
+        assertNotNull(throwable);
+        assertInstanceOf(MethodArgumentNotValidException.class, throwable);
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -89,7 +89,7 @@ public class TutoringBoardStartAtTest {
                 .title("title")
                 .content("content")
                 .tags("tags")
-                .recruitmentCapacity(5)
+                .capacity(5)
                 .startAt(LocalDate.now().atStartOfDay())
                 .endAt(LocalDate.now().atStartOfDay())
                 .department(department)

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -50,7 +50,7 @@ class TutoringBoardStartAtTest {
     void setUp() throws JSONException {
         json.put("title", "title");
         json.put("tags", "tags");
-        json.put("recruitmentCapacity", 5);
+        json.put("capacity", 5);
         json.put("content", "content");
         json.put("departmentType", DepartmentType.DEPT_2001);
     }

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -99,7 +99,7 @@ class TutoringBoardStartAtTest {
                 .thenReturn(tutoringBoard);
 
         json.put("startAt", LocalDate.now().atStartOfDay());
-        json.put("endAt", LocalDate.now().atStartOfDay());
+        json.put("endAt", LocalDate.now().atStartOfDay().plusDays(1));
 
         // when
         MockHttpServletRequestBuilder httpContent = post("/tutoring")

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -123,8 +123,6 @@ public class TutoringBoardStartAtTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString());
 
-        //TODO 정확한 예외 클래스 검증
-
         // then
         MvcResult result = mockMvc.perform(content)
                 .andExpect(status().isBadRequest())

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -37,6 +37,8 @@ class TutoringBoardStartAtTest {
 
     private final JSONObject json = new JSONObject();
 
+    private final String REQUEST_URL = "/tutoring-board";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -63,7 +65,7 @@ class TutoringBoardStartAtTest {
         json.put("endAt", LocalDateTime.of(1999, 10, 30, 23, 59, 59));
 
         // when
-        MockHttpServletRequestBuilder content = post("/tutoring")
+        MockHttpServletRequestBuilder content = post(REQUEST_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString());
 
@@ -102,7 +104,7 @@ class TutoringBoardStartAtTest {
         json.put("endAt", LocalDate.now().atStartOfDay().plusDays(1));
 
         // when
-        MockHttpServletRequestBuilder httpContent = post("/tutoring")
+        MockHttpServletRequestBuilder httpContent = post(REQUEST_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString());
 
@@ -119,7 +121,7 @@ class TutoringBoardStartAtTest {
         json.put("endAt", null);
 
         // when
-        MockHttpServletRequestBuilder content = post("/tutoring")
+        MockHttpServletRequestBuilder content = post(REQUEST_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString());
 


### PR DESCRIPTION
Close #28 

## 작업 내역

- 튜터링 게시판 정보에 따른 데이터 DB 저장
  - Spring Security Context Holder에 등록된 사용자 id를 통해 작성자 식별
- 학과별 튜터링 게시판 조회를 위한 API 구현
  - 특정 학과의 게시판만 조회하는 SQL 구현
- 특정 게시판 id를 통해 조회하는 API 구현
  - 특정 게시판 id로 데이터를 조회하는 SQL 구현

- 위 기능에 대한 테스트 구현
  - [x] 모집 시작일 (startAt)이 현재보다 과거라면 예외처리
  - [x] 모집 기간이 최소 기간(1일)보다 짧다면 예외처리
  - [x] 모집 기간이 최대 기간(4주)보다 길면 예외처리
  - [x] 모집 종료일이 시작일보다 빠르다면 예외처리
  - [x] 모집 종료 시간이 시작 시간보다 빠르다면 예외처리
  - [x] 모집 시작일이 현재로부터 3개월 이후라면 예외처리


- 부가 처리(개선)
  - 데이터가 존재하지 않는 환경에서 공지 크롤링 테스트
  - BaseEntity에 isDeleted가 기본값 false를 가질 수 있도록 `@Builder.Default` 추가
  - MemberService 를 구현체가 아닌 인터페이스로 수정