### PR TITLE
데이터 생성일자 및 수정일 위치 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/DongsoopApplication.java
+++ b/src/main/java/com/dongsoop/dongsoop/DongsoopApplication.java
@@ -2,10 +2,12 @@ package com.dongsoop.dongsoop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class DongsoopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dongsoop/dongsoop/board/Board.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/Board.java
@@ -3,13 +3,10 @@ package com.dongsoop.dongsoop.board;
 import com.dongsoop.dongsoop.common.BaseEntity;
 import com.dongsoop.dongsoop.member.entity.Member;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.NoArgsConstructor;
@@ -28,22 +25,8 @@ public abstract class Board extends BaseEntity {
     @Column(name = "content", length = 500, nullable = false)
     private String content;
 
-    @Embedded
-    @NotNull
-    private BoardDate boardDate;
-
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author", nullable = false, updatable = false)
     private Member author;
-
-    @PrePersist
-    public void onPrePersist() {
-        this.boardDate = new BoardDate();
-    }
-
-    @PreUpdate
-    public void onPreUpdate() {
-        this.boardDate.updateDate();
-    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -1,19 +1,33 @@
 package com.dongsoop.dongsoop.common;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @SuperBuilder
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @Setter
     @Builder.Default
     @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
     private boolean isDeleted = false;
+
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -34,7 +34,7 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                         tutoringBoard.title,
                         tutoringBoard.content,
                         tutoringBoard.tags,
-                        tutoringBoard.boardDate.createdAt))
+                        tutoringBoard.createdAt))
                 .from(tutoringBoard)
                 .leftJoin(tutoringApplication)
                 .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))
@@ -61,8 +61,8 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                                 tutoringBoard.endAt,
                                 tutoringBoard.department.id,
                                 tutoringBoard.author.nickname,
-                                tutoringBoard.boardDate.createdAt.as("createdAt"),
-                                tutoringBoard.boardDate.updatedAt.as("updatedAt"),
+                                tutoringBoard.createdAt.as("createdAt"),
+                                tutoringBoard.updatedAt.as("updatedAt"),
                                 tutoringApplication.id.member.count().intValue()
                         ))
                         .from(tutoringBoard)

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.tutoring.service;
 
-import com.dongsoop.dongsoop.board.BoardDate;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
@@ -65,7 +64,6 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 .startAt(request.getStartAt())
                 .endAt(request.getEndAt())
                 .capacity(request.getCapacity())
-                .boardDate(new BoardDate())
                 .build();
     }
 }

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -99,7 +99,7 @@ class TutoringBoardCreateTest {
         assertThat(board)
                 .usingRecursiveComparison()
                 .ignoringExpectedNullFields()
-                .ignoringFields("id", "boardDate.createdAt", "boardDate.updatedAt")
+                .ignoringFields("id", "createdAt", "updatedAt")
                 .isEqualTo(compareBoard);
     }
 }


### PR DESCRIPTION
### 작업 내용

- Board 클래스 내 createdAt, updatedAt 필드를 BaseEntity로 이동
- createdAt과 updatedAt을 각 이벤트에 맞게 초기화 되고, 업데이트 되도록 설정