### PR TITLE
JPA Auditing 설정 위치에 따른 컨트롤러 테스트 실패 문제 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/DongsoopApplication.java
+++ b/src/main/java/com/dongsoop/dongsoop/DongsoopApplication.java
@@ -2,12 +2,10 @@ package com.dongsoop.dongsoop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableJpaAuditing
 public class DongsoopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dongsoop/dongsoop/config/JpaAuditingConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/config/JpaAuditingConfig.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+    // JpaAuditingConfig를 분리한 이유는 Application 클래스의 책임을 줄이기 위함이다.
+    // 책임을 줄여 Test 환경에서 JpaAuditingConfig를 사용하지 않도록 설정할 수 있다.
+}


### PR DESCRIPTION
Close #33 

`@EnableJpaAuditing`을 Application 클래스에 선언하여 발생한 문제입니다.

정확하게는 WebMvcTest 테스트 환경에서는 Spring MVC(컨트롤러 등)와 관련된 빈만 로드하는 슬라이스 테스트로,
이 테스트에서는 JPA 관련 Entity, Repository 등의 빈은 로드되지 않습니다.  
그런데 Application에 `@EnableJpaAuditing` 가 정의되어 JPA 관련 빈을 필요로 하게 되어 발생한 문제입니다.

위 문제를 Application이 아닌 별도 `@Configuration` 클래스로 분리하여 해결하였습니다.
WebMvcTest는 Application 클래스를 기준으로 로드하기에 분리된 클래스는 로드하지 않아 해결되었습니다.