### PR TITLE
튜터링 게시글 응답 정보 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -20,10 +20,6 @@ public abstract class RecruitmentBoard extends Board {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
-    @NotNull
-    @Column(name = "capacity", nullable = false, columnDefinition = "INT DEFAULT 0")
-    private Integer capacity;
-
     @Column(name = "tags", length = 100)
     private String tags;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/CreateTutoringBoardRequest.java
@@ -6,7 +6,6 @@ import com.dongsoop.dongsoop.date.MaxDuration;
 import com.dongsoop.dongsoop.date.MinDuration;
 import com.dongsoop.dongsoop.date.TodayOrFuture;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -32,10 +31,6 @@ public class CreateTutoringBoardRequest {
 
     @NotBlank
     private String tags;
-
-    @NotNull
-    @Min(1)
-    private Integer capacity;
 
     @NotNull
     @MaxDate(month = 3)

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardDetails.java
@@ -19,8 +19,6 @@ public class TutoringBoardDetails {
 
     private String tags;
 
-    private Integer capacity;
-
     private LocalDateTime startAt;
 
     private LocalDateTime endAt;

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -16,6 +16,8 @@ public class TutoringBoardOverview {
 
     private Integer volunteer;
 
+    private LocalDateTime startAt;
+
     private LocalDateTime endAt;
 
     private String title;
@@ -23,6 +25,4 @@ public class TutoringBoardOverview {
     private String content;
 
     private String tags;
-
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/dto/TutoringBoardOverview.java
@@ -12,8 +12,6 @@ public class TutoringBoardOverview {
 
     private Long id;
 
-    private Integer capacity;
-
     private Integer volunteer;
 
     private LocalDateTime startAt;

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -29,7 +29,6 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
 
         return queryFactory.select(Projections.constructor(TutoringBoardOverview.class,
                         tutoringBoard.id,
-                        tutoringBoard.capacity,
                         tutoringApplication.id.member.count().intValue(),
                         tutoringBoard.startAt,
                         tutoringBoard.endAt,
@@ -57,7 +56,6 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                                 tutoringBoard.title,
                                 tutoringBoard.content,
                                 tutoringBoard.tags,
-                                tutoringBoard.capacity,
                                 tutoringBoard.startAt,
                                 tutoringBoard.endAt,
                                 tutoringBoard.department.id,

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -22,7 +22,8 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
 
     private final PageableUtil pageableUtil;
 
-    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment, Pageable pageable) {
+    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment,
+                                                                        Pageable pageable) {
         QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
         QTutoringApplication tutoringApplication = QTutoringApplication.tutoringApplication;
 
@@ -30,11 +31,11 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                         tutoringBoard.id,
                         tutoringBoard.capacity,
                         tutoringApplication.id.member.count().intValue(),
+                        tutoringBoard.startAt,
                         tutoringBoard.endAt,
                         tutoringBoard.title,
                         tutoringBoard.content,
-                        tutoringBoard.tags,
-                        tutoringBoard.createdAt))
+                        tutoringBoard.tags))
                 .from(tutoringBoard)
                 .leftJoin(tutoringApplication)
                 .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))

--- a/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/tutoring/service/TutoringBoardServiceImpl.java
@@ -63,7 +63,6 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 .department(departmentReference)
                 .startAt(request.getStartAt())
                 .endAt(request.getEndAt())
-                .capacity(request.getCapacity())
                 .build();
     }
 }

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -29,7 +29,6 @@ class TutoringBoardCreateTest {
     private final String VALID_TITLE = "This is a test title";
     private final String VALID_CONTENT = "This is a test content";
     private final String VALID_TAGS = "tag1, tag2";
-    private final Integer VALID_RECRUITMENT_CAPACITY = 5;
     private final DepartmentType VALID_DEPARTMENT_TYPE = DepartmentType.DEPT_2001;
     private final LocalDateTime VALID_START_AT = LocalDateTime.of(2099, 1, 1, 0, 0);
     private final LocalDateTime VALID_END_AT = LocalDateTime.of(2099, 12, 31, 23, 59);
@@ -54,7 +53,6 @@ class TutoringBoardCreateTest {
                 .title(VALID_TITLE)
                 .content(VALID_CONTENT)
                 .tags(VALID_TAGS)
-                .capacity(VALID_RECRUITMENT_CAPACITY)
                 .startAt(VALID_START_AT)
                 .endAt(VALID_END_AT)
                 .departmentType(VALID_DEPARTMENT_TYPE)
@@ -89,7 +87,6 @@ class TutoringBoardCreateTest {
                 .title(VALID_TITLE)
                 .content(VALID_CONTENT)
                 .tags(VALID_TAGS)
-                .capacity(VALID_RECRUITMENT_CAPACITY)
                 .startAt(VALID_START_AT)
                 .endAt(VALID_END_AT)
                 .department(department)

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
@@ -245,7 +245,6 @@ class TutoringBoardRecruitDateTest {
         JSONObject json = new JSONObject();
         json.put("title", "title");
         json.put("tags", "tags");
-        json.put("capacity", 5);
         json.put("content", "content");
         json.put("departmentType", DepartmentType.DEPT_2001);
         json.put("startAt", startAt.toString());

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -52,7 +52,6 @@ class TutoringBoardStartAtTest {
     void setUp() throws JSONException {
         json.put("title", "title");
         json.put("tags", "tags");
-        json.put("capacity", 5);
         json.put("content", "content");
         json.put("departmentType", DepartmentType.DEPT_2001);
     }
@@ -91,7 +90,6 @@ class TutoringBoardStartAtTest {
                 .title("title")
                 .content("content")
                 .tags("tags")
-                .capacity(5)
                 .startAt(LocalDate.now().atStartOfDay())
                 .endAt(LocalDate.now().atStartOfDay())
                 .department(department)


### PR DESCRIPTION
## 수정사항

- 튜터링 상세 정보 반환 시 생성일자를 제거하고 시작일자를 포함한 정보 응답
- 모집 정원 필드 제거