### PR TITLE
숨겨진(불필요한) 텍스트 크롤링 대상에서 제외

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/notice/NoticeSubjectNotAvailableException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/notice/NoticeSubjectNotAvailableException.java
@@ -1,0 +1,8 @@
+package com.dongsoop.dongsoop.exception.domain.notice;
+
+public class NoticeSubjectNotAvailableException extends RuntimeException {
+
+    public NoticeSubjectNotAvailableException() {
+        super("공지사항 제목 파싱 중 오류 발생");
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
@@ -5,6 +5,7 @@ import com.dongsoop.dongsoop.exception.domain.notice.NoticeSubjectNotAvailableEx
 import com.dongsoop.dongsoop.notice.entity.NoticeDetails;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -76,23 +77,16 @@ public class NoticeParser {
     }
 
     public String parseTitle(Element row) {
-        Element subjectElement = row.getElementsByClass("td-subject")
-                .first();
+        Element subjectElement = row.selectFirst(".td-subject");
 
         if (subjectElement == null) {
             throw new NoticeSubjectNotAvailableException();
         }
 
-        Elements subjectTextElement = subjectElement.getElementsByTag("strong");
+        Element subjectTextElement = subjectElement.selectFirst("strong");
 
-        // strong 태그가 없으면 td-subject 내용 전체 반환
-        if (subjectTextElement.isEmpty()) {
-            return subjectElement.text();
-        }
-
-        // strong 태그가 있으면 strong 태그 내용만 반환
-        return subjectTextElement.first() // subjectTextElement가 비어있는지 확인했기 때문에 추가 검증하지 않음
-                .text();
+        // strong 클래스가 있다면 반환하고 없다면 subject 내용 전체 반환
+        return Objects.requireNonNullElse(subjectTextElement, subjectElement).text();
     }
 
     public String parseLink(Element row) {

--- a/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class NoticeParser {
 
+    private static final String TD_SUBJECT_SELECTOR = ".td-subject";
+
     private static final Pattern DEPARTMENT_NOTICE_LINK_PATTERN = Pattern.compile(
             "^/combBbs/dmu/\\d+/\\d+/(\\d+)/view.do$");
     private static final Pattern UNIVERSITY_NOTICE_LINK_PATTERN = Pattern.compile(
@@ -77,7 +79,7 @@ public class NoticeParser {
     }
 
     public String parseTitle(Element row) {
-        Element subjectElement = row.selectFirst(".td-subject");
+        Element subjectElement = row.selectFirst(TD_SUBJECT_SELECTOR);
 
         if (subjectElement == null) {
             throw new NoticeSubjectNotAvailableException();
@@ -90,8 +92,7 @@ public class NoticeParser {
     }
 
     public String parseLink(Element row) {
-        Element titleElement = row.getElementsByClass("td-subject")
-                .first();
+        Element titleElement = row.selectFirst(TD_SUBJECT_SELECTOR);
         if (titleElement == null) {
             return "";
         }

--- a/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeParser.java
@@ -91,12 +91,8 @@ public class NoticeParser {
         }
 
         // strong 태그가 있으면 strong 태그 내용만 반환
-        Element textElement = subjectTextElement.first();
-        if (textElement == null) {
-            throw new NoticeSubjectNotAvailableException();
-        }
-
-        return textElement.text();
+        return subjectTextElement.first() // subjectTextElement가 비어있는지 확인했기 때문에 추가 검증하지 않음
+                .text();
     }
 
     public String parseLink(Element row) {


### PR DESCRIPTION
## 작업 내용

- 공지사항 크롤링 시 `td-subject` 클래스 내 `strong` 태그가 존재하는지 확인
- strong 태그가 존재한다면 strong태그의 내용만 가져오도록 수정
- strong 태그가 없는 경우 기존과 같이 td-subject 내 텍스트를 가져오도록 작업