### PR TITLE
채팅 기능 리팩토링

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateGroupRoomRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateGroupRoomRequest.java
@@ -11,4 +11,5 @@ import java.util.Set;
 @AllArgsConstructor
 public class CreateGroupRoomRequest {
     private Set<String> participants;
+    private String title;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessage.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessage.java
@@ -1,13 +1,11 @@
 package com.dongsoop.dongsoop.chat.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,6 +13,7 @@ public class ChatMessage {
     private String messageId;
     private String roomId;
     private Long senderId;
+    private String senderNickName;
     private String content;
     private LocalDateTime timestamp;
     private MessageType type;

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessageEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessageEntity.java
@@ -3,12 +3,14 @@ package com.dongsoop.dongsoop.chat.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "chat_messages")
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -21,6 +23,9 @@ public class ChatMessageEntity {
 
     @Column(nullable = false)
     private Long senderId;
+
+    @Column(nullable = false)
+    private String senderNickName;
 
     @Column(nullable = false, length = 1000)
     private String content;
@@ -36,6 +41,7 @@ public class ChatMessageEntity {
                 .messageId(this.messageId)
                 .roomId(this.roomId)
                 .senderId(this.senderId)
+                .senderNickName(this.senderNickName)
                 .content(this.content)
                 .timestamp(this.timestamp)
                 .type(this.type)

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
@@ -1,9 +1,6 @@
 package com.dongsoop.dongsoop.chat.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -11,14 +8,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoom {
     private static final int BACKUP_DAYS_THRESHOLD = 25;
+    private static final String DEFAULT_GROUP_TITLE = "그룹 채팅";
 
     private String roomId;
+    private String title;
     private Set<Long> participants;
     private Long managerId;
     private boolean isGroupChat;
@@ -27,71 +27,84 @@ public class ChatRoom {
     private Set<Long> kickedUsers;
 
     public static ChatRoom create(Long user1, Long user2) {
-        String roomId = UUID.randomUUID().toString();
-        Set<Long> participants = new HashSet<>();
-        participants.add(user1);
-        participants.add(user2);
-        LocalDateTime now = LocalDateTime.now();
-
         return ChatRoom.builder()
-                .roomId(roomId)
-                .participants(participants)
-                .createdAt(now)
-                .lastActivityAt(now)
+                .roomId(generateRandomRoomId())
+                .participants(createParticipantSet(user1, user2))
+                .createdAt(getCurrentTime())
+                .lastActivityAt(getCurrentTime())
                 .kickedUsers(new HashSet<>())
                 .build();
     }
 
-    public static ChatRoom createWithParticipants(Set<Long> participants, Long creatorId) {
-        String roomId = UUID.randomUUID().toString();
-        LocalDateTime now = LocalDateTime.now();
-
+    public static ChatRoom createWithParticipantsAndTitle(Set<Long> participants, Long creatorId, String title) {
         return ChatRoom.builder()
-                .roomId(roomId)
+                .roomId(generateRandomRoomId())
+                .title(title)
                 .participants(new HashSet<>(participants))
                 .managerId(creatorId)
                 .isGroupChat(true)
-                .createdAt(now)
-                .lastActivityAt(now)
+                .createdAt(getCurrentTime())
+                .lastActivityAt(getCurrentTime())
                 .kickedUsers(new HashSet<>())
                 .build();
     }
 
+    private static String generateRandomRoomId() {
+        return UUID.randomUUID().toString();
+    }
+
+    private static Set<Long> createParticipantSet(Long user1, Long user2) {
+        Set<Long> participants = new HashSet<>();
+        participants.add(user1);
+        participants.add(user2);
+        return participants;
+    }
+
+    private static LocalDateTime getCurrentTime() {
+        return LocalDateTime.now();
+    }
+
     public ChatRoomEntity toChatRoomEntity() {
-        LocalDateTime effectiveCreatedAt = Optional.ofNullable(this.createdAt)
-                .orElseGet(() -> LocalDateTime.now().minusDays(BACKUP_DAYS_THRESHOLD));
-
-        LocalDateTime effectiveLastActivityAt = Optional.ofNullable(this.lastActivityAt)
-                .orElseGet(LocalDateTime::now);
-
         return ChatRoomEntity.builder()
                 .roomId(this.roomId)
+                .title(this.title)
                 .isGroupChat(this.isGroupChat)
                 .managerId(this.managerId)
                 .participants(new HashSet<>(this.participants))
-                .createdAt(effectiveCreatedAt)
-                .lastActivityAt(effectiveLastActivityAt)
+                .createdAt(getEffectiveCreatedAt())
+                .lastActivityAt(getEffectiveLastActivityAt())
                 .build();
     }
 
     public void updateActivity() {
-        this.lastActivityAt = LocalDateTime.now();
+        this.lastActivityAt = getCurrentTime();
     }
 
     public void kickUser(Long userId) {
         participants.remove(userId);
-        getKickedUsersSet().add(userId);
+        ensureKickedUsersSet().add(userId);
         updateActivity();
     }
 
     public boolean isKicked(Long userId) {
-        return getKickedUsersSet().contains(userId);
+        return ensureKickedUsersSet().contains(userId);
     }
 
-    private Set<Long> getKickedUsersSet() {
-        if (kickedUsers == null) {
-            kickedUsers = new HashSet<>();
-        }
-        return kickedUsers;
+    private LocalDateTime getEffectiveCreatedAt() {
+        return Optional.ofNullable(this.createdAt)
+                .orElseGet(() -> getCurrentTime().minusDays(BACKUP_DAYS_THRESHOLD));
+    }
+
+    private LocalDateTime getEffectiveLastActivityAt() {
+        return Optional.ofNullable(this.lastActivityAt)
+                .orElseGet(LocalDateTime::now);
+    }
+
+    private Set<Long> ensureKickedUsersSet() {
+        return Optional.ofNullable(kickedUsers)
+                .orElseGet(() -> {
+                    kickedUsers = new HashSet<>();
+                    return kickedUsers;
+                });
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoomEntity.java
@@ -20,6 +20,9 @@ public class ChatRoomEntity {
     @Id
     private String roomId;
 
+    @Column(length = 100)
+    private String title;
+
     @Column(nullable = false)
     private boolean isGroupChat;
 
@@ -38,6 +41,7 @@ public class ChatRoomEntity {
     public ChatRoom toChatRoom() {
         return ChatRoom.builder()
                 .roomId(this.roomId)
+                .title(this.title)
                 .participants(participants)
                 .managerId(this.managerId)
                 .isGroupChat(this.isGroupChat)

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatBackupService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatBackupService.java
@@ -1,7 +1,6 @@
 package com.dongsoop.dongsoop.chat.service;
 
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
-import com.dongsoop.dongsoop.chat.entity.ChatRoomEntity;
 import com.dongsoop.dongsoop.chat.repository.ChatRoomJpaRepository;
 import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,42 +9,53 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 @Service
 @RequiredArgsConstructor
 public class ChatBackupService {
     private static final int BACKUP_DAYS_THRESHOLD = 25;
+    private static final int MIN_GROUP_SIZE = 2;
 
     private final RedisChatRepository redisChatRepository;
     private final ChatRoomJpaRepository chatRoomJpaRepository;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void backupExpiringRooms() {
-        LocalDateTime cutoffTime = LocalDateTime.now().minusDays(BACKUP_DAYS_THRESHOLD);
-        List<ChatRoom> expiringSoonRooms = redisChatRepository.findRoomsCreatedBefore(cutoffTime);
+        LocalDateTime cutoffTime = calculateBackupCutoffTime();
+        List<ChatRoom> expiringSoonRooms = findExpiringSoonRooms(cutoffTime);
 
-        Predicate<ChatRoom> isGroupChatNotBackedUp = room ->
-                isGroupRoom(room.getParticipants().size()) &&
-                        !chatRoomJpaRepository.existsById(room.getRoomId());
-
-        expiringSoonRooms.stream()
-                .filter(isGroupChatNotBackedUp)
-                .forEach(this::backupRoomAndMessages);
+        processBackupCandidates(expiringSoonRooms);
     }
 
-    private boolean isGroupRoom(int participantCount) {
-        return participantCount >= 2;
+    private LocalDateTime calculateBackupCutoffTime() {
+        return LocalDateTime.now().minusDays(BACKUP_DAYS_THRESHOLD);
     }
 
-    private void backupRoomAndMessages(ChatRoom room) {
-        if (room.isGroupChat()) {
-            backupRoom(room);
-        }
+    private List<ChatRoom> findExpiringSoonRooms(LocalDateTime cutoffTime) {
+        return redisChatRepository.findRoomsCreatedBefore(cutoffTime);
     }
 
-    private void backupRoom(ChatRoom room) {
-        ChatRoomEntity entity = room.toChatRoomEntity();
-        chatRoomJpaRepository.save(entity);
+    private void processBackupCandidates(List<ChatRoom> rooms) {
+        rooms.stream()
+                .filter(createGroupRoomFilter())
+                .filter(createNotBackedUpFilter())
+                .forEach(this::backupGroupRoom);
+    }
+
+    private Predicate<ChatRoom> createGroupRoomFilter() {
+        return room -> room.getParticipants().size() >= MIN_GROUP_SIZE;
+    }
+
+    private Predicate<ChatRoom> createNotBackedUpFilter() {
+        return room -> !chatRoomJpaRepository.existsById(room.getRoomId());
+    }
+
+    private void backupGroupRoom(ChatRoom room) {
+        Optional.of(room)
+                .filter(ChatRoom::isGroupChat)
+                .map(ChatRoom::toChatRoomEntity)
+                .ifPresent(chatRoomJpaRepository::save);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -23,7 +24,8 @@ public class ChatService {
 
     public ChatService(@Qualifier("redisChatRepository") ChatRepository chatRepository,
                        ChatValidator chatValidator,
-                       ChatSyncService chatSyncService) {
+                       ChatSyncService chatSyncService
+    ) {
         this.chatRepository = chatRepository;
         this.chatValidator = chatValidator;
         this.chatSyncService = chatSyncService;
@@ -31,42 +33,28 @@ public class ChatService {
 
     public ChatRoom createOneToOneChatRoom(Long userId, Long targetUserId) {
         chatValidator.validateSelfChat(userId, targetUserId);
+        validateNegativeUserIds(userId, targetUserId);
 
-        if (userId < 0 || targetUserId < 0) {
-            throw new UnauthorizedChatAccessException();
-        }
-
-        return chatRepository.findRoomByParticipants(userId, targetUserId)
-                .orElseGet(() -> createRoom(userId, targetUserId));
+        return findExistingRoomOrCreate(userId, targetUserId);
     }
 
-    public ChatRoom createGroupChatRoom(Long creatorId, Set<Long> participants) {
-        validateGroupParticipants(participants);
-        participants.add(creatorId);
+    public ChatRoom createGroupChatRoom(Long creatorId, Set<Long> participants, String title) {
+        validateMinimumParticipants(participants);
 
-        ChatRoom room = ChatRoom.createWithParticipants(participants, creatorId);
+        Set<Long> allParticipants = buildParticipantSet(participants, creatorId);
+        ChatRoom room = ChatRoom.createWithParticipantsAndTitle(allParticipants, creatorId, title);
         return chatRepository.saveRoom(room);
     }
 
     public ChatRoom kickUserFromRoom(String roomId, Long requesterId, Long userToKick) {
         ChatRoom room = getChatRoomById(roomId);
-
         chatValidator.validateManagerPermission(room, requesterId);
         chatValidator.validateKickableUser(room, userToKick);
 
-        room.kickUser(userToKick);
-        chatRepository.saveRoom(room);
+        executeUserKick(room, userToKick);
+        createKickNotification(roomId, requesterId, userToKick);
 
-        createUserKickedMessage(roomId, requesterId, userToKick);
-
-        return room;
-    }
-
-    private ChatMessage createUserKickedMessage(String roomId, Long managerId, Long kickedUserId) {
-        String content = kickedUserId + "님이 채팅방에서 추방되었습니다.";
-        ChatMessage message = createSystemMessage(roomId, managerId, content, MessageType.LEAVE);
-        chatRepository.saveMessage(message);
-        return message;
+        return chatRepository.saveRoom(room);
     }
 
     public void enterChatRoom(String roomId, Long userId) {
@@ -74,116 +62,187 @@ public class ChatService {
     }
 
     public ChatMessage processMessage(ChatMessage message) {
-        ChatMessage validatedMessage = chatValidator.validateAndEnrichMessage(message);
-        chatRepository.saveMessage(validatedMessage);
-        return validatedMessage;
+        ChatMessage enrichedMessage = chatValidator.validateAndEnrichMessage(message);
+        chatRepository.saveMessage(enrichedMessage);
+        return enrichedMessage;
     }
 
     public ChatMessage createEnterMessage(String roomId, Long userId) {
         chatValidator.validateUserForRoom(roomId, userId);
-
-        ChatMessage message = createSystemMessage(
-                roomId,
-                userId,
-                userId + "님이 입장하셨습니다.",
-                MessageType.ENTER
-        );
-
-        chatRepository.saveMessage(message);
-        return message;
+        return buildAndSaveEnterMessage(roomId, userId);
     }
 
     public List<ChatMessage> getChatHistory(String roomId, Long userId) {
         chatValidator.validateUserForRoom(roomId, userId);
-        List<ChatMessage> messages = chatRepository.findMessagesByRoomId(roomId);
-
-        if (messages.isEmpty()) {
-            messages = chatSyncService.restoreMessagesFromDatabase(roomId);
-        }
-
-        return messages;
+        return retrieveMessagesFromCacheOrDatabase(roomId);
     }
 
     public ChatRoom getChatRoomById(String roomId) {
-        return chatRepository.findRoomById(roomId)
-                .orElseGet(() -> Optional.ofNullable(chatSyncService.restoreGroupChatRoom(roomId))
-                        .orElseThrow(ChatRoomNotFoundException::new));
+        return findRoomByIdOrRestore(roomId);
     }
 
     public List<ChatMessage> syncMessages(String roomId, Long userId, List<ChatMessage> clientMessages) {
         chatValidator.validateUserForRoom(roomId, userId);
+
         List<ChatMessage> serverMessages = chatRepository.findMessagesByRoomId(roomId);
         List<ChatMessage> newMessages = chatValidator.filterDuplicateMessages(serverMessages, clientMessages);
 
-        newMessages.forEach(this::processMessage);
-
+        processNewMessages(newMessages);
         return chatRepository.findMessagesByRoomId(roomId);
     }
 
     public void recreateRoomIfNeeded(String roomId, Long userId, List<ChatMessage> localMessages) {
+        attemptRoomRecreation(roomId, userId, localMessages);
+    }
+
+    public List<ChatRoom> getRoomsForUserId(Long userId) {
+        List<ChatRoom> allRooms = chatRepository.findRoomsByUserId(userId);
+        return filterNonKickedRooms(allRooms, userId);
+    }
+
+    private void validateNegativeUserIds(Long userId, Long targetUserId) {
+        Stream.of(userId, targetUserId)
+                .filter(id -> id < 0)
+                .findAny()
+                .ifPresent(id -> {
+                    throw new UnauthorizedChatAccessException();
+                });
+    }
+
+    private ChatRoom findExistingRoomOrCreate(Long userId, Long targetUserId) {
+        return chatRepository.findRoomByParticipants(userId, targetUserId)
+                .orElseGet(() -> createNewOneToOneRoom(userId, targetUserId));
+    }
+
+    private ChatRoom createNewOneToOneRoom(Long user1, Long user2) {
+        ChatRoom room = ChatRoom.create(user1, user2);
+        return chatRepository.saveRoom(room);
+    }
+
+    private void validateMinimumParticipants(Set<Long> participants) {
+        Optional.of(participants.size())
+                .filter(size -> size < 0)
+                .ifPresent(size -> {
+                    throw new IllegalArgumentException("그룹 채팅 참여자 수가 올바르지 않습니다.");
+                });
+    }
+
+    private Set<Long> buildParticipantSet(Set<Long> participants, Long creatorId) {
+        Set<Long> allParticipants = new HashSet<>(participants);
+        allParticipants.add(creatorId);
+        return allParticipants;
+    }
+
+    private void executeUserKick(ChatRoom room, Long userToKick) {
+        room.kickUser(userToKick);
+    }
+
+    private void createKickNotification(String roomId, Long managerId, Long kickedUserId) {
+        String content = "사용자가 채팅방에서 추방되었습니다.";
+
+        ChatMessage notification = buildSystemMessage(roomId, managerId, "시스템", content, MessageType.LEAVE);
+        chatRepository.saveMessage(notification);
+    }
+
+    private ChatMessage buildAndSaveEnterMessage(String roomId, Long userId) {
+        String content = "사용자가 입장하셨습니다.";
+        ChatMessage enterMessage = buildSystemMessage(roomId, userId, "시스템", content, MessageType.ENTER);
+        chatRepository.saveMessage(enterMessage);
+        return enterMessage;
+    }
+
+    private ChatMessage buildSystemMessage(String roomId, Long senderId, String senderNickName, String content, MessageType type) {
+        return ChatMessage.builder()
+                .messageId(UUID.randomUUID().toString())
+                .roomId(roomId)
+                .senderId(senderId)
+                .senderNickName(senderNickName)
+                .content(content)
+                .timestamp(LocalDateTime.now())
+                .type(type)
+                .build();
+    }
+
+    private List<ChatMessage> retrieveMessagesFromCacheOrDatabase(String roomId) {
+        List<ChatMessage> cachedMessages = chatRepository.findMessagesByRoomId(roomId);
+
+        return Optional.of(cachedMessages)
+                .filter(messages -> !messages.isEmpty())
+                .orElseGet(() -> chatSyncService.restoreMessagesFromDatabase(roomId));
+    }
+
+    private ChatRoom findRoomByIdOrRestore(String roomId) {
+        return chatRepository.findRoomById(roomId)
+                .orElseGet(() -> restoreRoomFromDatabase(roomId));
+    }
+
+    private ChatRoom restoreRoomFromDatabase(String roomId) {
+        return Optional.ofNullable(chatSyncService.restoreGroupChatRoom(roomId))
+                .orElseThrow(ChatRoomNotFoundException::new);
+    }
+
+    private void processNewMessages(List<ChatMessage> newMessages) {
+        newMessages.forEach(this::processMessage);
+    }
+
+    private void attemptRoomRecreation(String roomId, Long userId, List<ChatMessage> localMessages) {
+        Optional.of(roomId)
+                .map(id -> tryUpdateExistingRoom(id, userId, localMessages))
+                .orElseGet(() -> recreateFromMessages(roomId, userId, localMessages));
+    }
+
+    private Boolean tryUpdateExistingRoom(String roomId, Long userId, List<ChatMessage> localMessages) {
         try {
-            validateAndUpdateRoom(roomId, userId);
+            updateExistingRoomParticipants(roomId, userId);
             syncMessages(roomId, userId, localMessages);
+            return true;
         } catch (ChatRoomNotFoundException e) {
-            handleRoomNotFound(roomId, userId, localMessages);
+            recreateFromMessages(roomId, userId, localMessages);
+            return false;
         }
     }
 
-    private void validateAndUpdateRoom(String roomId, Long userId) {
+    private void updateExistingRoomParticipants(String roomId, Long userId) {
         ChatRoom room = getChatRoomById(roomId);
 
-        if (!room.getParticipants().contains(userId)) {
-            room.getParticipants().add(userId);
-            chatRepository.saveRoom(room);
-        }
+        Optional.of(userId)
+                .filter(id -> !room.getParticipants().contains(id))
+                .ifPresent(id -> {
+                    room.getParticipants().add(id);
+                    chatRepository.saveRoom(room);
+                });
     }
 
-    private void handleRoomNotFound(String roomId, Long userId, List<ChatMessage> localMessages) {
-        if (localMessages.isEmpty()) {
-            throw new ChatRoomNotFoundException();
-        }
-
-        recreateRoomFromMessages(roomId, userId, localMessages);
-    }
-
-    public ChatRoom recreateRoomFromMessages(String roomId, Long userId, List<ChatMessage> clientMessages) {
-        if (clientMessages.isEmpty()) {
-            throw new IllegalArgumentException("메시지가 없어 채팅방을 재생성할 수 없습니다.");
-        }
+    private Boolean recreateFromMessages(String roomId, Long userId, List<ChatMessage> clientMessages) {
+        validateNonEmptyMessages(clientMessages);
 
         Set<Long> participants = extractParticipantsFromMessages(userId, clientMessages);
-        ChatRoom newRoom = createRoomWithId(roomId, participants);
+        createRoomWithSpecificId(roomId, participants);
+        saveEnrichedMessages(clientMessages);
 
-        clientMessages.forEach(message -> {
-            enrichMessageIfNeeded(message);
-            chatRepository.saveMessage(message);
-        });
-
-        return newRoom;
+        return true;
     }
 
-    private void enrichMessageIfNeeded(ChatMessage message) {
-        if (message.getMessageId() == null) {
-            message.setMessageId(UUID.randomUUID().toString());
-        }
-        if (message.getTimestamp() == null) {
-            message.setTimestamp(LocalDateTime.now());
-        }
-        if (message.getType() == null) {
-            message.setType(MessageType.CHAT);
-        }
+    private void validateNonEmptyMessages(List<ChatMessage> messages) {
+        Optional.of(messages)
+                .filter(List::isEmpty)
+                .ifPresent(emptyList -> {
+                    throw new IllegalArgumentException("메시지가 없어 채팅방을 재생성할 수 없습니다.");
+                });
     }
 
     private Set<Long> extractParticipantsFromMessages(Long userId, List<ChatMessage> messages) {
         Set<Long> participants = new HashSet<>();
         participants.add(userId);
 
-        messages.forEach(message -> participants.add(message.getSenderId()));
+        messages.stream()
+                .map(ChatMessage::getSenderId)
+                .forEach(participants::add);
 
         return participants;
     }
 
-    private ChatRoom createRoomWithId(String roomId, Set<Long> participants) {
+    private void createRoomWithSpecificId(String roomId, Set<Long> participants) {
         ChatRoom newRoom = ChatRoom.builder()
                 .roomId(roomId)
                 .participants(participants)
@@ -191,33 +250,58 @@ public class ChatService {
                 .lastActivityAt(LocalDateTime.now())
                 .build();
 
-        return chatRepository.saveRoom(newRoom);
+        chatRepository.saveRoom(newRoom);
     }
 
-    private ChatMessage createSystemMessage(String roomId, Long userId, String content, MessageType type) {
-        return ChatMessage.builder()
-                .messageId(UUID.randomUUID().toString())
-                .roomId(roomId)
-                .senderId(userId)
-                .content(content)
-                .timestamp(LocalDateTime.now())
-                .type(type)
-                .build();
+    private void saveEnrichedMessages(List<ChatMessage> clientMessages) {
+        clientMessages.stream()
+                .peek(this::enrichMessageFields)
+                .forEach(chatRepository::saveMessage);
     }
 
-    private ChatRoom createRoom(Long user1, Long user2) {
-        ChatRoom room = ChatRoom.create(user1, user2);
-        return chatRepository.saveRoom(room);
+    private void enrichMessageFields(ChatMessage message) {
+        setMessageIdIfMissing(message);
+        setTimestampIfMissing(message);
+        setTypeIfMissing(message);
+        setSenderNickNameIfMissing(message);
     }
 
-    private void validateGroupParticipants(Set<Long> participants) {
-        if (participants.size() < 2) {
-            throw new IllegalArgumentException("그룹 채팅에는 최소 2명 이상의 참여자가 필요합니다.");
-        }
+    private void setMessageIdIfMissing(ChatMessage message) {
+        Optional.ofNullable(message.getMessageId())
+                .orElseGet(() -> {
+                    String newId = UUID.randomUUID().toString();
+                    message.setMessageId(newId);
+                    return newId;
+                });
     }
 
-    public List<ChatRoom> getRoomsForUserId(Long userId) {
-        List<ChatRoom> rooms = chatRepository.findRoomsByUserId(userId);
+    private void setTimestampIfMissing(ChatMessage message) {
+        Optional.ofNullable(message.getTimestamp())
+                .orElseGet(() -> {
+                    LocalDateTime now = LocalDateTime.now();
+                    message.setTimestamp(now);
+                    return now;
+                });
+    }
+
+    private void setTypeIfMissing(ChatMessage message) {
+        Optional.ofNullable(message.getType())
+                .orElseGet(() -> {
+                    message.setType(MessageType.CHAT);
+                    return MessageType.CHAT;
+                });
+    }
+
+    private void setSenderNickNameIfMissing(ChatMessage message) {
+        Optional.ofNullable(message.getSenderNickName())
+                .orElseGet(() -> {
+                    String defaultName = "사용자" + message.getSenderId();
+                    message.setSenderNickName(defaultName);
+                    return defaultName;
+                });
+    }
+
+    private List<ChatRoom> filterNonKickedRooms(List<ChatRoom> rooms, Long userId) {
         return rooms.stream()
                 .filter(room -> !room.isKicked(userId))
                 .toList();

--- a/src/main/java/com/dongsoop/dongsoop/config/WebSocketConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/config/WebSocketConfig.java
@@ -34,7 +34,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .withSockJS()
                 .setDisconnectDelay(30 * 1000)
                 .setHeartbeatTime(15 * 1000)
-                .setSessionCookieNeeded(true)
                 .setWebSocketEnabled(true)
                 .setStreamBytesLimit(512 * 1024)
                 .setHttpMessageCacheSize(1000);


### PR DESCRIPTION
- 채팅방 및 메시지 조회/저장 로직이 공통화되고, 필터링 유틸이 추가됨
- 백업/복원 및 메시지 동기화, 중복 메시지 필터 등 안정성이 개선

- 이전 채팅 참여자가 ID로 보였던 것을 사용자의 닉네임으로 보이도록 수정
- 그룹채팅방 생성시 해당 모집했던 글의 제목을 가져와 채팅방 제목으로 설정하도록 구현