### PR TITLE
JWT Filter 레이어 예외처리

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ProblemDetail> handleGlobalException(CustomException exception) {
+    public ResponseEntity<ProblemDetail> handleCustomException(CustomException exception) {
         return createExceptionResponse(exception, exception.getHttpStatus());
     }
 
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
 
     // 정의되지 않은 예외처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ProblemDetail> handleException(Exception exception) {
+    public ResponseEntity<ProblemDetail> handleGlobalException(Exception exception) {
         return createInternalServerErrorResponse(exception);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/jwt/TokenMalformedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/jwt/TokenMalformedException.java
@@ -12,7 +12,7 @@ public class TokenMalformedException extends CustomException {
     }
 
     public TokenMalformedException(Exception e) {
-        super("토큰이 올바르지 않습니다:", HTTP_STATUS, e);
+        super("토큰이 올바르지 않습니다.", HTTP_STATUS, e);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/jwt/TokenMalformedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/jwt/TokenMalformedException.java
@@ -5,12 +5,14 @@ import org.springframework.http.HttpStatus;
 
 public class TokenMalformedException extends CustomException {
 
+    private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
     public TokenMalformedException() {
-        super("토큰이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+        super("토큰이 올바르지 않습니다.", HTTP_STATUS);
     }
 
     public TokenMalformedException(Exception e) {
-        super("토큰이 올바르지 않습니다.", HttpStatus.BAD_REQUEST, e);
+        super("토큰이 올바르지 않습니다:", HTTP_STATUS, e);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -93,6 +93,6 @@ public class JwtFilter extends OncePerRequestFilter {
             Exception exception
     ) {
         log.error("JWT Filter processing failed: {}", exception.getMessage(), exception);
-        exceptionResolver.resolveException(request, response, null, exception);
+        exceptionResolver.resolveException(request, response, this, exception);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -93,6 +93,6 @@ public class JwtFilter extends OncePerRequestFilter {
             Exception exception
     ) {
         log.error("JWT Filter processing failed: {}", exception.getMessage(), exception);
-        exceptionResolver.resolveException(request, response, this, exception);
+        exceptionResolver.resolveException(request, response, null, exception);
     }
 }


### PR DESCRIPTION
JWT Filter에서 사용자 토큰 검증 시 예외가 발생한다면 Spring MVC 레이어로 예외 처리를 위임하여 Response를 생성하도록 수정되었습니다.

- 전역 예외처리의 중복 코드를 메서드로 분리하였습니다.
- 일반 예외(ex. IllegalArgsException)에 대해 일관된 응답을 처리하는 코드를 추가했습니다.