### PR TITLE
채팅 매니저 권한 로직 추가 및 사용자 닉네임 필드삭제

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -64,14 +64,12 @@ public class ChatController {
         Long currentUserId = getCurrentUserId();
         chatService.enterChatRoom(roomId, currentUserId);
 
-        List<ChatMessage> messages = chatService.getChatHistory(roomId, currentUserId);
+        ChatRoom room = chatService.getChatRoomById(roomId);
 
-        Map<Long, String> participants = messages.stream()
-                .filter(msg -> msg.getSenderId() != null && !"시스템".equals(msg.getSenderNickName()))
+        Map<Long, String> participants = room.getParticipants().stream()
                 .collect(Collectors.toMap(
-                        ChatMessage::getSenderId,
-                        ChatMessage::getSenderNickName,
-                        (existing, replacement) -> existing
+                        participantId -> participantId,
+                        memberService::getNicknameById
                 ));
 
         return ResponseEntity.ok(participants);
@@ -114,9 +112,10 @@ public class ChatController {
         String userToKickNickname = kickUserRequest.getUserId();
         Long userToKickId = memberService.getLoginAuthenticateByNickname(userToKickNickname).getId();
 
-        ChatRoom updatedRoom = chatService.kickUserFromRoom(roomId, currentUserId, userToKickId, userToKickNickname);
+        ChatRoom updatedRoom = chatService.kickUserFromRoom(roomId, currentUserId, userToKickId);
         return ResponseEntity.ok(updatedRoom);
     }
+
 
     private Long getCurrentUserId() {
         Member member = memberService.getMemberReferenceByContext();

--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -109,13 +109,14 @@ public class ChatController {
             @PathVariable("roomId") String roomId,
             @RequestBody KickUserRequest kickUserRequest) {
         Long currentUserId = getCurrentUserId();
+
         String userToKickNickname = kickUserRequest.getUserId();
-        Long userToKickId = memberService.getLoginAuthenticateByNickname(userToKickNickname).getId();
+        LoginAuthenticate userToKickAuth = memberService.getLoginAuthenticateByNickname(userToKickNickname);
+        Long userToKickId = userToKickAuth.getId();
 
         ChatRoom updatedRoom = chatService.kickUserFromRoom(roomId, currentUserId, userToKickId);
         return ResponseEntity.ok(updatedRoom);
     }
-
 
     private Long getCurrentUserId() {
         Member member = memberService.getMemberReferenceByContext();

--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -109,10 +109,7 @@ public class ChatController {
             @PathVariable("roomId") String roomId,
             @RequestBody KickUserRequest kickUserRequest) {
         Long currentUserId = getCurrentUserId();
-
-        String userToKickNickname = kickUserRequest.getUserId();
-        LoginAuthenticate userToKickAuth = memberService.getLoginAuthenticateByNickname(userToKickNickname);
-        Long userToKickId = userToKickAuth.getId();
+        Long userToKickId = kickUserRequest.getUserId();
 
         ChatRoom updatedRoom = chatService.kickUserFromRoom(roomId, currentUserId, userToKickId);
         return ResponseEntity.ok(updatedRoom);

--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
@@ -17,7 +17,7 @@ import java.security.Principal;
 public class ChatSocketController {
 
     private final ChatService chatService;
-    private final MemberService memberService;  // 추가
+    private final MemberService memberService;
 
     @MessageMapping("/message/{roomId}")
     @SendTo("/topic/chat/room/{roomId}")

--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
@@ -2,7 +2,6 @@ package com.dongsoop.dongsoop.chat.controller;
 
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.service.ChatService;
-import com.dongsoop.dongsoop.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -17,7 +16,6 @@ import java.security.Principal;
 public class ChatSocketController {
 
     private final ChatService chatService;
-    private final MemberService memberService;
 
     @MessageMapping("/message/{roomId}")
     @SendTo("/topic/chat/room/{roomId}")
@@ -27,10 +25,8 @@ public class ChatSocketController {
             Principal principal) {
 
         Long userId = extractUserIdFromPrincipal(principal);
-        String userNickname = getUserNicknameById(userId);
 
         message.setSenderId(userId);
-        message.setSenderNickName(userNickname);
         message.setRoomId(roomId);
 
         return chatService.processMessage(message);
@@ -48,9 +44,5 @@ public class ChatSocketController {
 
     private Long extractUserIdFromPrincipal(Principal principal) {
         return Long.parseLong(principal.getName());
-    }
-
-    private String getUserNicknameById(Long userId) {
-        return memberService.getNicknameById(userId);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/KickUserRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/KickUserRequest.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KickUserRequest {
-    private String userId;
+    private Long userId;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessage.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessage.java
@@ -13,7 +13,6 @@ public class ChatMessage {
     private String messageId;
     private String roomId;
     private Long senderId;
-    private String senderNickName;
     private String content;
     private LocalDateTime timestamp;
     private MessageType type;

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessageEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatMessageEntity.java
@@ -24,9 +24,6 @@ public class ChatMessageEntity {
     @Column(nullable = false)
     private Long senderId;
 
-    @Column(nullable = false)
-    private String senderNickName;
-
     @Column(nullable = false, length = 1000)
     private String content;
 
@@ -41,7 +38,6 @@ public class ChatMessageEntity {
                 .messageId(this.messageId)
                 .roomId(this.roomId)
                 .senderId(this.senderId)
-                .senderNickName(this.senderNickName)
                 .content(this.content)
                 .timestamp(this.timestamp)
                 .type(this.type)

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
@@ -1,11 +1,10 @@
 package com.dongsoop.dongsoop.chat.entity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 @Setter
@@ -29,6 +28,8 @@ public class ChatRoom {
 
     @Builder.Default
     private Set<Long> kickedUsers = new HashSet<>();
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<Long, String> participantNicknames;
 
     public static ChatRoom create(Long user1, Long user2) {
         return ChatRoom.builder()
@@ -113,5 +114,21 @@ public class ChatRoom {
             kickedUsers = new HashSet<>();
         }
         return kickedUsers;
+    }
+
+    public void setParticipantNicknames(Map<Long, String> nicknames) {
+        this.participantNicknames = nicknames;
+    }
+
+    public String getParticipantNickname(Long userId) {
+        return Optional.ofNullable(participantNicknames)
+                .map(nicknames -> nicknames.get(userId))
+                .orElse(null);
+    }
+
+    public boolean isManager(Long userId) {
+        return Optional.ofNullable(managerId)
+                .map(id -> id.equals(userId))
+                .orElse(false);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/repository/InMemoryChatRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/repository/InMemoryChatRepository.java
@@ -10,7 +10,6 @@ import java.util.function.Predicate;
 
 @Repository
 public class InMemoryChatRepository implements ChatRepository {
-    private static final int ONE_TO_ONE_PARTICIPANT_COUNT = 2;
 
     private final Map<String, ChatRoom> rooms = new ConcurrentHashMap<>();
     private final Map<String, List<ChatMessage>> messages = new ConcurrentHashMap<>();
@@ -65,8 +64,9 @@ public class InMemoryChatRepository implements ChatRepository {
     }
 
     private Predicate<ChatRoom> createOneToOneRoomFilter() {
-        return room -> room.getParticipants().size() == ONE_TO_ONE_PARTICIPANT_COUNT;
+        return room -> !room.isGroupChat();
     }
+
 
     private Predicate<ChatRoom> createParticipantMatchFilter(Long user1, Long user2) {
         return room -> {

--- a/src/main/java/com/dongsoop/dongsoop/chat/repository/RedisChatRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/repository/RedisChatRepository.java
@@ -16,7 +16,6 @@ public class RedisChatRepository implements ChatRepository {
     private static final String ROOM_KEY_PREFIX = "chat:room:";
     private static final String MESSAGE_KEY_PREFIX = "chat:message:";
     private static final String MESSAGE_LIST_PREFIX = "chat:messages:";
-    private static final int ONE_TO_ONE_PARTICIPANT_COUNT = 2;
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -114,7 +113,7 @@ public class RedisChatRepository implements ChatRepository {
     private Predicate<ChatRoom> createOneToOneParticipantFilter(Long user1, Long user2) {
         return room -> {
             Set<Long> participants = room.getParticipants();
-            return participants.size() == ONE_TO_ONE_PARTICIPANT_COUNT &&
+            return !room.isGroupChat() &&
                     participants.contains(user1) &&
                     participants.contains(user2);
         };

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatBackupService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatBackupService.java
@@ -16,7 +16,6 @@ import java.util.function.Predicate;
 @RequiredArgsConstructor
 public class ChatBackupService {
     private static final int BACKUP_DAYS_THRESHOLD = 25;
-    private static final int MIN_GROUP_SIZE = 2;
 
     private final RedisChatRepository redisChatRepository;
     private final ChatRoomJpaRepository chatRoomJpaRepository;
@@ -45,7 +44,7 @@ public class ChatBackupService {
     }
 
     private Predicate<ChatRoom> createGroupRoomFilter() {
-        return room -> room.getParticipants().size() >= MIN_GROUP_SIZE;
+        return ChatRoom::isGroupChat;
     }
 
     private Predicate<ChatRoom> createNotBackedUpFilter() {
@@ -54,7 +53,6 @@ public class ChatBackupService {
 
     private void backupGroupRoom(ChatRoom room) {
         Optional.of(room)
-                .filter(ChatRoom::isGroupChat)
                 .map(ChatRoom::toChatRoomEntity)
                 .ifPresent(chatRoomJpaRepository::save);
     }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -52,12 +52,14 @@ public class ChatService {
         return chatRepository.saveRoom(room);
     }
 
-    public ChatRoom kickUserFromRoom(String roomId, Long requesterId, Long userToKick, String userToKickNickname) {
+    public ChatRoom kickUserFromRoom(String roomId, Long requesterId, Long userToKick) {
         ChatRoom room = getChatRoomById(roomId);
         chatValidator.validateManagerPermission(room, requesterId);
         chatValidator.validateKickableUser(room, userToKick);
 
         executeUserKick(room, userToKick);
+
+        String userToKickNickname = memberService.getNicknameById(userToKick);
         createKickNotificationWithNickname(roomId, requesterId, userToKickNickname);
 
         return chatRepository.saveRoom(room);
@@ -150,7 +152,7 @@ public class ChatService {
         room.kickUser(userToKick);
     }
 
-    private void createKickNotificationWithNickname(String roomId, Long managerId, String kickedUserNickname) {  // 새 메서드
+    private void createKickNotificationWithNickname(String roomId, Long managerId, String kickedUserNickname) {
         String managerNickname = getUserNicknameById(managerId);
         String content = kickedUserNickname + "님이 채팅방에서 추방되었습니다.";
         ChatMessage notification = buildSystemMessage(roomId, managerId, managerNickname, content, MessageType.LEAVE);
@@ -165,7 +167,7 @@ public class ChatService {
         return enterMessage;
     }
 
-    private ChatMessage buildSystemMessage(String roomId, Long senderId, String senderNickname, String content, MessageType type) {  // 수정
+    private ChatMessage buildSystemMessage(String roomId, Long senderId, String senderNickname, String content, MessageType type) {
         return ChatMessage.builder()
                 .messageId(UUID.randomUUID().toString())
                 .roomId(roomId)
@@ -312,7 +314,7 @@ public class ChatService {
         }
     }
 
-    private void setSenderNickNameIfMissing(ChatMessage message) {  // 수정
+    private void setSenderNickNameIfMissing(ChatMessage message) {
         if (message.getSenderNickName() == null) {
             String nickname = getUserNicknameById(message.getSenderId());
             message.setSenderNickName(nickname);

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -139,13 +139,13 @@ public class ChatService {
     }
 
     private void createKickNotification(String roomId, Long kickedUserId) {
-        String content = "사용자 " + kickedUserId + "님이 채팅방에서 추방되었습니다.";
+        String content = kickedUserId.toString();
         ChatMessage notification = buildSystemMessage(roomId, kickedUserId, content, MessageType.LEAVE);
         chatRepository.saveMessage(notification);
     }
 
     private ChatMessage buildAndSaveEnterMessage(String roomId, Long userId) {
-        String content = "사용자 " + userId + "님이 입장하셨습니다.";
+        String content = userId.toString();
         ChatMessage enterMessage = buildSystemMessage(roomId, userId, content, MessageType.ENTER);
         chatRepository.saveMessage(enterMessage);
         return enterMessage;

--- a/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.chat.entity.MessageType;
 import com.dongsoop.dongsoop.chat.repository.ChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatSyncService;
 import com.dongsoop.dongsoop.exception.domain.websocket.*;
+import com.dongsoop.dongsoop.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -22,11 +23,14 @@ public class ChatValidator {
 
     private final ChatRepository chatRepository;
     private final ChatSyncService chatSyncService;
+    private final MemberService memberService;
 
     public ChatValidator(@Qualifier("redisChatRepository") ChatRepository chatRepository,
-                         ChatSyncService chatSyncService) {
+                         ChatSyncService chatSyncService,
+                         MemberService memberService) {
         this.chatRepository = chatRepository;
         this.chatSyncService = chatSyncService;
+        this.memberService = memberService;
     }
 
     public void validateUserForRoom(String roomId, Long userId) {
@@ -155,11 +159,15 @@ public class ChatValidator {
         }
     }
 
-    private void setSenderNickNameIfAbsent(ChatMessage message) {
+    private void setSenderNickNameIfAbsent(ChatMessage message) {  // 수정
         if (message.getSenderNickName() == null) {
-            String defaultName = "사용자" + message.getSenderId();
-            message.setSenderNickName(defaultName);
+            String nickname = getUserNicknameById(message.getSenderId());
+            message.setSenderNickName(nickname);
         }
+    }
+
+    private String getUserNicknameById(Long userId) {  // 새 메서드
+        return memberService.getNicknameById(userId);
     }
 
     private Set<String> extractMessageIds(List<ChatMessage> messages) {

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -15,4 +15,6 @@ public interface MemberService {
     LoginAuthenticate getLoginAuthenticateByNickname(String nickname);
 
     Member getMemberReferenceByContext();
+
+    String getNicknameById(Long userId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -8,11 +8,7 @@ import com.dongsoop.dongsoop.exception.domain.member.InvalidPasswordFormatExcept
 import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
 import com.dongsoop.dongsoop.jwt.TokenGenerator;
 import com.dongsoop.dongsoop.jwt.dto.IssuedToken;
-import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
-import com.dongsoop.dongsoop.member.dto.LoginDetails;
-import com.dongsoop.dongsoop.member.dto.LoginMemberDetails;
-import com.dongsoop.dongsoop.member.dto.LoginRequest;
-import com.dongsoop.dongsoop.member.dto.SignupRequest;
+import com.dongsoop.dongsoop.member.dto.*;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.repository.MemberRepository;
 import com.dongsoop.dongsoop.member.repository.MemberRepositoryCustom;
@@ -21,9 +17,6 @@ import com.dongsoop.dongsoop.role.entity.Role;
 import com.dongsoop.dongsoop.role.entity.RoleType;
 import com.dongsoop.dongsoop.role.repository.MemberRoleRepository;
 import com.dongsoop.dongsoop.role.repository.RoleRepository;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -33,6 +26,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -151,5 +148,11 @@ public class MemberServiceImpl implements MemberService {
         if (isExists) {
             throw new EmailDuplicatedException();
         }
+    }
+
+    public String getNicknameById(Long userId) {
+        return memberRepository.findById(userId)
+                .map(Member::getNickname)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }


### PR DESCRIPTION
- 그룹채팅방 매니저 권한의 강퇴기능의 로직 수정
- 1:1채팅방, 그룹채팅방인지 설정하는 로직보강
- 사용자의 닉네임 필드 삭제 -> Id로 변경