### PR TITLE
학습 구성원 모집 게시글 전체 학과 대상 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectBoardController.java
@@ -43,11 +43,19 @@ public class ProjectBoardController {
                 .build();
     }
 
+    @GetMapping
+    public ResponseEntity<List<ProjectBoardOverview>> getProjectBoardList(Pageable pageable) {
+        List<ProjectBoardOverview> projectBoardOverviews = projectBoardService.getBoardByPage(pageable);
+
+        return ResponseEntity.ok(projectBoardOverviews);
+    }
+
     @GetMapping("/department/{departmentType}")
-    public ResponseEntity<List<ProjectBoardOverview>> getProjectBoardList(
+    public ResponseEntity<List<ProjectBoardOverview>> getProjectBoardListByDepartment(
             @PathVariable("departmentType") DepartmentType departmentType,
             Pageable pageable) {
-        List<ProjectBoardOverview> projectBoardOverviews = projectBoardService.getBoardByPage(departmentType,
+        List<ProjectBoardOverview> projectBoardOverviews = projectBoardService.getBoardByPageAndDepartmentType(
+                departmentType,
                 pageable);
 
         return ResponseEntity.ok(projectBoardOverviews);

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/dto/ProjectBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/dto/ProjectBoardOverview.java
@@ -1,6 +1,9 @@
 package com.dongsoop.dongsoop.recruitment.project.dto;
 
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public record ProjectBoardOverview(
 
@@ -10,6 +13,22 @@ public record ProjectBoardOverview(
         LocalDateTime endAt,
         String title,
         String content,
-        String tags
+        String tags,
+        List<DepartmentType> departmentTypeList
 ) {
+    public ProjectBoardOverview(Long id, Integer volunteer, LocalDateTime startAt, LocalDateTime endAt, String title,
+                                String content, String tags, String departmentTypes) {
+        this(
+                id,
+                volunteer,
+                startAt,
+                endAt,
+                title,
+                content,
+                tags,
+                Arrays.stream(departmentTypes.split(","))
+                        .map(v -> DepartmentType.valueOf(v.trim()))
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustom.java
@@ -9,7 +9,10 @@ import org.springframework.data.domain.Pageable;
 
 public interface ProjectBoardRepositoryCustom {
 
-    List<ProjectBoardOverview> findProjectBoardOverviewsByPage(DepartmentType departmentType, Pageable pageable);
+    List<ProjectBoardOverview> findProjectBoardOverviewsByPageAndDepartmentType(DepartmentType departmentType,
+                                                                                Pageable pageable);
+
+    List<ProjectBoardOverview> findProjectBoardOverviewsByPage(Pageable pageable);
 
     Optional<ProjectBoardDetails> findProjectBoardDetails(Long projectBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustomImpl.java
@@ -46,13 +46,7 @@ public class ProjectBoardRepositoryCustomImpl implements ProjectBoardRepositoryC
                 .limit(pageable.getPageSize())
                 .groupBy(projectBoard.id)
                 .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort(), projectBoard))
-                .having(
-                        Expressions.numberTemplate(
-                                        Integer.class,
-                                        "SUM(CASE WHEN {0} = {1} THEN 1 ELSE 0 END)",
-                                        projectBoardDepartment.id.department.id,
-                                        Expressions.constant(departmentType))
-                                .gt(0))
+                .having(equalDepartmentType(departmentType))
                 .fetch();
     }
 
@@ -121,5 +115,14 @@ public class ProjectBoardRepositoryCustomImpl implements ProjectBoardRepositoryC
                 projectBoard.tags,
                 Expressions.stringTemplate("string_agg({0}, ',')",
                         projectBoardDepartment.id.department.id));
+    }
+
+    private BooleanExpression equalDepartmentType(DepartmentType departmentType) {
+        return Expressions.numberTemplate(
+                        Integer.class,
+                        "SUM(CASE WHEN {0} = {1} THEN 1 ELSE 0 END)",
+                        projectBoardDepartment.id.department.id,
+                        Expressions.constant(departmentType))
+                .gt(0);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardService.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface ProjectBoardService {
 
-    List<ProjectBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable);
+    List<ProjectBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable);
+
+    List<ProjectBoardOverview> getBoardByPage(Pageable pageable);
 
     ProjectBoard create(CreateProjectBoardRequest request);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
@@ -53,8 +53,13 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
         return projectBoard;
     }
 
-    public List<ProjectBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable) {
-        return projectBoardRepositoryCustom.findProjectBoardOverviewsByPage(departmentType, pageable);
+    public List<ProjectBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType,
+                                                                      Pageable pageable) {
+        return projectBoardRepositoryCustom.findProjectBoardOverviewsByPageAndDepartmentType(departmentType, pageable);
+    }
+
+    public List<ProjectBoardOverview> getBoardByPage(Pageable pageable) {
+        return projectBoardRepositoryCustom.findProjectBoardOverviewsByPage(pageable);
     }
 
     public ProjectBoardDetails getBoardDetailsById(Long projectBoardId) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyBoardController.java
@@ -44,10 +44,18 @@ public class StudyBoardController {
     }
 
     @GetMapping("/department/{departmentType}")
-    public ResponseEntity<List<StudyBoardOverview>> getStudyBoardList(
+    public ResponseEntity<List<StudyBoardOverview>> getStudyBoardListByDepartmentType(
             @PathVariable("departmentType") DepartmentType departmentType,
             Pageable pageable) {
-        List<StudyBoardOverview> studyBoardOverviews = studyBoardService.getBoardByPage(departmentType, pageable);
+        List<StudyBoardOverview> studyBoardOverviews = studyBoardService.getBoardByPageAndDepartmentType(departmentType,
+                pageable);
+
+        return ResponseEntity.ok(studyBoardOverviews);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<StudyBoardOverview>> getStudyBoardList(Pageable pageable) {
+        List<StudyBoardOverview> studyBoardOverviews = studyBoardService.getBoardByPage(pageable);
 
         return ResponseEntity.ok(studyBoardOverviews);
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/dto/StudyBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/dto/StudyBoardOverview.java
@@ -1,6 +1,9 @@
 package com.dongsoop.dongsoop.recruitment.study.dto;
 
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public record StudyBoardOverview(
 
@@ -10,6 +13,22 @@ public record StudyBoardOverview(
         LocalDateTime endAt,
         String title,
         String content,
-        String tags
+        String tags,
+        List<DepartmentType> departmentTypeList
 ) {
+    public StudyBoardOverview(Long id, Integer volunteer, LocalDateTime startAt, LocalDateTime endAt, String title,
+                              String content, String tags, String departmentTypes) {
+        this(
+                id,
+                volunteer,
+                startAt,
+                endAt,
+                title,
+                content,
+                tags,
+                Arrays.stream(departmentTypes.split(","))
+                        .map(v -> DepartmentType.valueOf(v.trim()))
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustom.java
@@ -9,7 +9,10 @@ import org.springframework.data.domain.Pageable;
 
 public interface StudyBoardRepositoryCustom {
 
-    List<StudyBoardOverview> findStudyBoardOverviewsByPage(DepartmentType departmentType, Pageable pageable);
+    List<StudyBoardOverview> findStudyBoardOverviewsByPageAndDepartmentType(DepartmentType departmentType,
+                                                                            Pageable pageable);
+
+    List<StudyBoardOverview> findStudyBoardOverviewsByPage(Pageable pageable);
 
     Optional<StudyBoardDetails> findStudyBoardDetails(Long studyBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.dongsoop.dongsoop.recruitment.study.dto.StudyBoardOverview;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyBoard;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyBoardDepartment;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -32,25 +33,19 @@ public class StudyBoardRepositoryCustomImpl implements StudyBoardRepositoryCusto
 
     private final PageableUtil pageableUtil;
 
-    public List<StudyBoardOverview> findStudyBoardOverviewsByPage(DepartmentType departmentType, Pageable pageable) {
+    public List<StudyBoardOverview> findStudyBoardOverviewsByPageAndDepartmentType(DepartmentType departmentType,
+                                                                                   Pageable pageable) {
         return queryFactory
-                .select(Projections.constructor(StudyBoardOverview.class,
-                        studyBoard.id,
-                        studyApply.id.member.countDistinct().intValue(),
-                        studyBoard.startAt,
-                        studyBoard.endAt,
-                        studyBoard.title,
-                        studyBoard.content,
-                        studyBoard.tags))
+                .select(getBoardOverviewExpression())
                 .from(studyBoard)
                 .leftJoin(studyApply)
                 .on(hasMatchingStudyBoardId(studyApply.id.studyBoard.id))
                 .leftJoin(studyBoardDepartment)
                 .on(hasMatchingStudyBoardId(studyBoardDepartment.id.studyBoard.id))
-                .where(equalDepartmentType(departmentType))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .groupBy(studyBoard.id)
+                .having(equalDepartmentType(departmentType))
                 .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort(), studyBoard))
                 .fetch();
     }
@@ -90,11 +85,44 @@ public class StudyBoardRepositoryCustomImpl implements StudyBoardRepositoryCusto
         return Optional.ofNullable(studyBoardDetails);
     }
 
+    public List<StudyBoardOverview> findStudyBoardOverviewsByPage(Pageable pageable) {
+        return queryFactory
+                .select(getBoardOverviewExpression())
+                .from(studyBoard)
+                .leftJoin(studyApply)
+                .on(hasMatchingStudyBoardId(studyApply.id.studyBoard.id))
+                .leftJoin(studyBoardDepartment)
+                .on(hasMatchingStudyBoardId(studyBoardDepartment.id.studyBoard.id))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .groupBy(studyBoard.id)
+                .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort(), studyBoard))
+                .fetch();
+    }
+
     private BooleanExpression hasMatchingStudyBoardId(NumberPath<Long> studyBoardId) {
         return studyBoard.id.eq(studyBoardId);
     }
 
+    private Expression<StudyBoardOverview> getBoardOverviewExpression() {
+        return Projections.constructor(StudyBoardOverview.class,
+                studyBoard.id,
+                studyApply.id.member.countDistinct().intValue(),
+                studyBoard.startAt,
+                studyBoard.endAt,
+                studyBoard.title,
+                studyBoard.content,
+                studyBoard.tags,
+                Expressions.stringTemplate("string_agg({0}, ',')",
+                        studyBoardDepartment.id.department.id));
+    }
+
     private BooleanExpression equalDepartmentType(DepartmentType departmentType) {
-        return studyBoardDepartment.id.department.id.eq(departmentType);
+        return Expressions.numberTemplate(
+                        Integer.class,
+                        "SUM(CASE WHEN {0} = {1} THEN 1 ELSE 0 END)",
+                        studyBoardDepartment.id.department.id,
+                        Expressions.constant(departmentType))
+                .gt(0);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardService.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface StudyBoardService {
 
-    List<StudyBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable);
+    List<StudyBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable);
+
+    List<StudyBoardOverview> getBoardByPage(Pageable pageable);
 
     StudyBoard create(CreateStudyBoardRequest request);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
@@ -52,8 +52,12 @@ public class StudyBoardServiceImpl implements StudyBoardService {
         return studyBoard;
     }
 
-    public List<StudyBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable) {
-        return studyBoardRepositoryCustom.findStudyBoardOverviewsByPage(departmentType, pageable);
+    public List<StudyBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable) {
+        return studyBoardRepositoryCustom.findStudyBoardOverviewsByPageAndDepartmentType(departmentType, pageable);
+    }
+
+    public List<StudyBoardOverview> getBoardByPage(Pageable pageable) {
+        return studyBoardRepositoryCustom.findStudyBoardOverviewsByPage(pageable);
     }
 
     public StudyBoardDetails getBoardDetailsById(Long studyBoardId) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringBoardController.java
@@ -27,10 +27,17 @@ public class TutoringBoardController {
     private final TutoringBoardService tutoringBoardService;
 
     @GetMapping("/department/{departmentType}")
-    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviews(
+    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviewsByDepartment(
             @PathVariable("departmentType") DepartmentType departmentType, Pageable pageable) {
-        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getBoardByPage(departmentType,
+        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getBoardByPageAndDepartmentType(
+                departmentType,
                 pageable);
+        return ResponseEntity.ok(tutoringBoardList);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TutoringBoardOverview>> getTutoringBoardOverviews(Pageable pageable) {
+        List<TutoringBoardOverview> tutoringBoardList = tutoringBoardService.getBoardByPage(pageable);
         return ResponseEntity.ok(tutoringBoardList);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/dto/TutoringBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/dto/TutoringBoardOverview.java
@@ -1,6 +1,8 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.dto;
 
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record TutoringBoardOverview(
 
@@ -10,6 +12,20 @@ public record TutoringBoardOverview(
         LocalDateTime endAt,
         String title,
         String content,
-        String tags
+        String tags,
+        List<DepartmentType> departmentTypeList
 ) {
+    public TutoringBoardOverview(Long id, Integer volunteer, LocalDateTime startAt, LocalDateTime endAt, String title,
+                                 String content, String tags, DepartmentType departmentType) {
+        this(
+                id,
+                volunteer,
+                startAt,
+                endAt,
+                title,
+                content,
+                tags,
+                List.of(departmentType)
+        );
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
-import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardOverview;
 import java.util.List;
@@ -9,8 +9,10 @@ import org.springframework.data.domain.Pageable;
 
 public interface TutoringBoardRepositoryCustom {
 
-    List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment,
-                                                                 Pageable pageable);
+    List<TutoringBoardOverview> findTutoringBoardOverviewsByPageAndDepartmentType(DepartmentType departmentType,
+                                                                                  Pageable pageable);
+
+    List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Pageable pageable);
 
     Optional<TutoringBoardDetails> findInformationById(Long tutoringBoardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -1,7 +1,7 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
 import com.dongsoop.dongsoop.common.PageableUtil;
-import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardOverview;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
@@ -26,8 +26,8 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
 
     private final PageableUtil pageableUtil;
 
-    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Department recruitmentDepartment,
-                                                                        Pageable pageable) {
+    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPageAndDepartmentType(DepartmentType departmentType,
+                                                                                         Pageable pageable) {
         return queryFactory.select(Projections.constructor(TutoringBoardOverview.class,
                         tutoringBoard.id,
                         tutoringApplication.id.member.count().intValue(),
@@ -35,11 +35,12 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                         tutoringBoard.endAt,
                         tutoringBoard.title,
                         tutoringBoard.content,
-                        tutoringBoard.tags))
+                        tutoringBoard.tags,
+                        tutoringBoard.department.id))
                 .from(tutoringBoard)
                 .leftJoin(tutoringApplication)
                 .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))
-                .where(tutoringBoard.department.eq(recruitmentDepartment))
+                .where(tutoringBoard.department.id.eq(departmentType))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .groupBy(tutoringBoard.id)
@@ -68,5 +69,25 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                         .where(tutoringBoard.id.eq(tutoringBoardId))
                         .groupBy(tutoringBoard.id, tutoringBoard.author.nickname)
                         .fetchOne());
+    }
+
+    public List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Pageable pageable) {
+        return queryFactory.select(Projections.constructor(TutoringBoardOverview.class,
+                        tutoringBoard.id,
+                        tutoringApplication.id.member.count().intValue(),
+                        tutoringBoard.startAt,
+                        tutoringBoard.endAt,
+                        tutoringBoard.title,
+                        tutoringBoard.content,
+                        tutoringBoard.tags,
+                        tutoringBoard.department.id))
+                .from(tutoringBoard)
+                .leftJoin(tutoringApplication)
+                .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .groupBy(tutoringBoard.id)
+                .orderBy(pageableUtil.getAllOrderSpecifiers(pageable.getSort(), tutoringBoard))
+                .fetch();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardService.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface TutoringBoardService {
 
-    List<TutoringBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable);
+    List<TutoringBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable);
+
+    List<TutoringBoardOverview> getBoardByPage(Pageable pageable);
 
     TutoringBoard create(CreateTutoringBoardRequest request);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
@@ -3,7 +3,6 @@ package com.dongsoop.dongsoop.recruitment.tutoring.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
-import com.dongsoop.dongsoop.exception.domain.department.DepartmentNotFoundException;
 import com.dongsoop.dongsoop.exception.domain.tutoring.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -14,7 +13,6 @@ import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringBoardRepository;
 import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringBoardRepositoryCustom;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,12 +29,14 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final MemberService memberService;
 
-    public List<TutoringBoardOverview> getBoardByPage(DepartmentType departmentType, Pageable pageable) {
-        Optional<Department> optionalRecruitmentDepartment = departmentRepository.findById(departmentType);
-        Department recruitmentDepartment = optionalRecruitmentDepartment.orElseThrow(
-                () -> new DepartmentNotFoundException(departmentType));
+    public List<TutoringBoardOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType,
+                                                                       Pageable pageable) {
+        return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPageAndDepartmentType(departmentType,
+                pageable);
+    }
 
-        return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPage(recruitmentDepartment, pageable);
+    public List<TutoringBoardOverview> getBoardByPage(Pageable pageable) {
+        return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPage(pageable);
     }
 
     public TutoringBoard create(CreateTutoringBoardRequest request) {


### PR DESCRIPTION
Close #73 

## 기능 설명(Description)

비회원의 경우 학과가 설정되어있지 않아, 전체 학과를 대상으로한 학습 구성원 모집 게시글 목록을 조회할 수 있도록 기능 추가

## 구현해야 할 세부 항목(Tasks/Checklist)

- [x] 학과 필터링이 포함되지 않은 학습 구성원 모집 게시글 조회 API 구현
   - [x] Controller
   - [x] Service
   - [x] Repository
- [x] DB 조회 시 중복 학과 조회 문제 해결을 위해 List -> Set 으로 변경
- [x] endAt이 현재 날짜보다 이전인 경우 조회하지 않도록 수정

![image](https://github.com/user-attachments/assets/3016915c-cd46-4534-b147-74435d1de950)
![image](https://github.com/user-attachments/assets/7836b545-2799-4ea3-ad53-f36bab218e71)
![image](https://github.com/user-attachments/assets/a4bfba91-cbff-4291-9cc1-5aeb35449368)
