### PR TITLE
모집 게시글 상세페이지 내 지원 여부 반환

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/authentication/NotAuthenticationException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/authentication/NotAuthenticationException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.authentication;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NotAuthenticationException extends CustomException {
+
+    public NotAuthenticationException() {
+        super("사용자의 인증 정보가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/project/ProjectRecruitmentAlreadyAppliedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/project/ProjectRecruitmentAlreadyAppliedException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.project;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ProjectRecruitmentAlreadyAppliedException extends CustomException {
+
+    public ProjectRecruitmentAlreadyAppliedException(Long memberId, Long boardId) {
+        super("이미 지원한 프로젝트 모집 게시글입니다. 사용자 ID: " + memberId + ", 게시글 ID: " + boardId, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/study/StudyRecruitmentAlreadyAppliedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/study/StudyRecruitmentAlreadyAppliedException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.study;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class StudyRecruitmentAlreadyAppliedException extends CustomException {
+
+    public StudyRecruitmentAlreadyAppliedException(Long memberId, Long boardId) {
+        super("이미 지원한 스터디 모집 게시글입니다. 사용자 ID: " + memberId + ", 게시글 ID: " + boardId, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/tutoring/TutoringRecruitmentAlreadyAppliedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/tutoring/TutoringRecruitmentAlreadyAppliedException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.tutoring;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TutoringRecruitmentAlreadyAppliedException extends CustomException {
+
+    public TutoringRecruitmentAlreadyAppliedException(Long memberId, Long boardId) {
+        super("이미 지원한 튜터링 모집 게시글입니다. 사용자 ID: " + memberId + ", 게시글 ID: " + boardId, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -17,4 +17,6 @@ public interface MemberService {
     Member getMemberReferenceByContext();
 
     String getNicknameById(Long userId);
+
+    Long getMemberIdByAuthentication();
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.member.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.service.DepartmentService;
+import com.dongsoop.dongsoop.exception.domain.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.exception.domain.member.EmailDuplicatedException;
 import com.dongsoop.dongsoop.exception.domain.member.InvalidPasswordFormatException;
 import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
@@ -157,5 +158,21 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findById(userId)
                 .map(Member::getNickname)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public Long getMemberIdByAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new NotAuthenticationException();
+        }
+
+        String id = authentication.getName();
+        if (StringUtils.hasText(id) && id.matches("\\d+")) {
+            return Long.valueOf(id);
+        }
+
+        throw new NotAuthenticationException();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/dto/ProjectBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/dto/ProjectBoardDetails.java
@@ -19,12 +19,14 @@ public record ProjectBoardDetails(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         Integer volunteer,
-        RecruitmentViewType viewType
+        RecruitmentViewType viewType,
+        boolean isAlreadyApplied
 ) {
 
     public ProjectBoardDetails(Long id, String title, String content, String tags, LocalDateTime startAt,
                                LocalDateTime endAt, String departmentTypes, String author, LocalDateTime createdAt,
-                               LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType) {
+                               LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType,
+                               boolean isAlreadyApplied) {
         this(
                 id,
                 title,
@@ -37,7 +39,8 @@ public record ProjectBoardDetails(
                 createdAt,
                 updatedAt,
                 volunteer,
-                viewType
+                viewType,
+                isAlreadyApplied
         );
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dongsoop.dongsoop.recruitment.project.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+
+public interface ProjectApplyRepositoryCustom {
+
+    boolean existsByBoardIdAndMember(Long boardId, Member member);
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
@@ -1,8 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.project.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
-
 public interface ProjectApplyRepositoryCustom {
 
-    boolean existsByBoardIdAndMember(Long boardId, Member member);
+    boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.recruitment.project.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.project.entity.QProjectApply;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +13,11 @@ public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryC
 
     private final JPAQueryFactory queryFactory;
 
-    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+    public boolean existsByBoardIdAndMemberId(Long boardId, Long memberId) {
         return queryFactory.selectOne()
                 .from(projectApply)
                 .where(projectApply.id.projectBoard.id.eq(boardId)
-                        .and(projectApply.id.member.eq(member)))
+                        .and(projectApply.id.member.id.eq(memberId)))
                 .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.dongsoop.dongsoop.recruitment.project.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.recruitment.project.entity.QProjectApply;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryCustom {
+
+    private static final QProjectApply projectApply = QProjectApply.projectApply;
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+        return queryFactory.selectOne()
+                .from(projectApply)
+                .where(projectApply.id.projectBoard.id.eq(boardId)
+                        .and(projectApply.id.member.eq(member)))
+                .fetchFirst() != null;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepository.java
@@ -1,10 +1,9 @@
 package com.dongsoop.dongsoop.recruitment.project.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectBoardRepository extends JpaRepository<ProjectBoard, Long> {
 
-    boolean existsByIdAndAuthor(Long id, Member author);
+    boolean existsByIdAndAuthorId(Long id, Long authorId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustom.java
@@ -15,5 +15,6 @@ public interface ProjectBoardRepositoryCustom {
 
     List<ProjectBoardOverview> findProjectBoardOverviewsByPage(Pageable pageable);
 
-    Optional<ProjectBoardDetails> findBoardDetailsByIdAndViewType(Long projectBoardId, RecruitmentViewType viewType);
+    Optional<ProjectBoardDetails> findBoardDetailsByIdAndViewType(Long projectBoardId, RecruitmentViewType viewType,
+                                                                  boolean isAlreadyApplied);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectBoardRepositoryCustomImpl.java
@@ -52,7 +52,8 @@ public class ProjectBoardRepositoryCustomImpl implements ProjectBoardRepositoryC
     }
 
     public Optional<ProjectBoardDetails> findBoardDetailsByIdAndViewType(Long projectBoardId,
-                                                                         RecruitmentViewType viewType) {
+                                                                         RecruitmentViewType viewType,
+                                                                         boolean isAlreadyApplied) {
         ProjectBoardDetails projectBoardDetails = queryFactory
                 .select(Projections.constructor(ProjectBoardDetails.class,
                         projectBoard.id,
@@ -66,7 +67,8 @@ public class ProjectBoardRepositoryCustomImpl implements ProjectBoardRepositoryC
                         projectBoard.createdAt,
                         projectBoard.updatedAt,
                         projectApply.id.member.count().intValue(),
-                        Expressions.constant(viewType)))
+                        Expressions.constant(viewType),
+                        Expressions.constant(isAlreadyApplied)))
                 .from(projectBoard)
                 .leftJoin(projectApply)
                 .on(hasMatchingProjectBoardId(projectApply.id.projectBoard.id))

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
@@ -3,7 +3,7 @@ package com.dongsoop.dongsoop.recruitment.project.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
-import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
+import com.dongsoop.dongsoop.exception.domain.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.exception.domain.project.ProjectBoardNotFound;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -69,16 +69,16 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
 
     public ProjectBoardDetails getBoardDetailsById(Long boardId) {
         try {
-            Member member = memberService.getMemberReferenceByContext();
-            boolean isOwner = projectBoardRepository.existsByIdAndAuthor(boardId, member);
+            Long memberId = memberService.getMemberIdByAuthentication();
+            boolean isOwner = projectBoardRepository.existsByIdAndAuthorId(boardId, memberId);
             if (isOwner) {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, member.getId());
+            boolean isAlreadyApplied = projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, memberId);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
-        } catch (MemberNotFoundException exception) {
+        } catch (NotAuthenticationException exception) {
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.GUEST);
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
@@ -75,7 +75,7 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = projectApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
+            boolean isAlreadyApplied = projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, member.getId());
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectBoardServiceImpl.java
@@ -11,11 +11,10 @@ import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.project.dto.CreateProjectBoardRequest;
 import com.dongsoop.dongsoop.recruitment.project.dto.ProjectBoardDetails;
 import com.dongsoop.dongsoop.recruitment.project.dto.ProjectBoardOverview;
-import com.dongsoop.dongsoop.recruitment.project.entity.ProjectApply.ProjectApplyKey;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoard;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoardDepartment;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoardDepartment.ProjectBoardDepartmentId;
-import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyRepository;
+import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardRepository;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardRepositoryCustom;
@@ -38,8 +37,8 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
     private final DepartmentRepository departmentRepository;
 
     private final ProjectBoardDepartmentRepository projectBoardDepartmentRepository;
-    
-    private final ProjectApplyRepository projectApplyRepository;
+
+    private final ProjectApplyRepositoryCustom projectApplyRepositoryCustom;
 
     @Transactional
     public ProjectBoard create(CreateProjectBoardRequest request) {
@@ -76,9 +75,7 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            ProjectBoard projectBoard = projectBoardRepository.getReferenceById(boardId);
-            ProjectApplyKey applyKey = new ProjectApplyKey(projectBoard, member);
-            boolean isAlreadyApplied = projectApplyRepository.existsById(applyKey);
+            boolean isAlreadyApplied = projectApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/dto/StudyBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/dto/StudyBoardDetails.java
@@ -19,11 +19,13 @@ public record StudyBoardDetails(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         Integer volunteer,
-        RecruitmentViewType viewType
+        RecruitmentViewType viewType,
+        boolean isAlreadyApplied
 ) {
     public StudyBoardDetails(Long id, String title, String content, String tags, LocalDateTime startAt,
                              LocalDateTime endAt, String departmentTypes, String author, LocalDateTime createdAt,
-                             LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType) {
+                             LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType,
+                             boolean isAlreadyApplied) {
         this(
                 id,
                 title,
@@ -36,7 +38,8 @@ public record StudyBoardDetails(
                 createdAt,
                 updatedAt,
                 volunteer,
-                viewType
+                viewType,
+                isAlreadyApplied
         );
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dongsoop.dongsoop.recruitment.study.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+
+public interface StudyApplyRepositoryCustom {
+
+    boolean existsByBoardIdAndMember(Long boardId, Member member);
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
@@ -1,8 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.study.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
-
 public interface StudyApplyRepositoryCustom {
 
-    boolean existsByBoardIdAndMember(Long boardId, Member member);
+    boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.dongsoop.dongsoop.recruitment.study.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCustom {
+
+    private static final QStudyApply studyApply = QStudyApply.studyApply;
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+        return queryFactory.selectOne()
+                .from(studyApply)
+                .where(studyApply.id.studyBoard.id.eq(boardId)
+                        .and(studyApply.id.member.eq(member)))
+                .fetchFirst() != null;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.recruitment.study.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +13,11 @@ public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCusto
 
     private final JPAQueryFactory queryFactory;
 
-    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+    public boolean existsByBoardIdAndMemberId(Long boardId, Long memberId) {
         return queryFactory.selectOne()
                 .from(studyApply)
                 .where(studyApply.id.studyBoard.id.eq(boardId)
-                        .and(studyApply.id.member.eq(member)))
+                        .and(studyApply.id.member.id.eq(memberId)))
                 .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepository.java
@@ -1,10 +1,9 @@
 package com.dongsoop.dongsoop.recruitment.study.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyBoardRepository extends JpaRepository<StudyBoard, Long> {
 
-    boolean existsByIdAndAuthor(Long id, Member author);
+    boolean existsByIdAndAuthorId(Long id, Long authorId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustom.java
@@ -15,5 +15,7 @@ public interface StudyBoardRepositoryCustom {
 
     List<StudyBoardOverview> findStudyBoardOverviewsByPage(Pageable pageable);
 
-    Optional<StudyBoardDetails> findBoardDetailsByIdAndViewType(Long studyBoardId, RecruitmentViewType viewType);
+    Optional<StudyBoardDetails> findBoardDetailsByIdAndViewType(Long studyBoardId,
+                                                                RecruitmentViewType viewType,
+                                                                boolean isAlreadyApplied);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyBoardRepositoryCustomImpl.java
@@ -52,7 +52,8 @@ public class StudyBoardRepositoryCustomImpl implements StudyBoardRepositoryCusto
     }
 
     public Optional<StudyBoardDetails> findBoardDetailsByIdAndViewType(Long studyBoardId,
-                                                                       RecruitmentViewType viewType) {
+                                                                       RecruitmentViewType viewType,
+                                                                       boolean isAlreadyApplied) {
         StudyBoardDetails studyBoardDetails = queryFactory
                 .select(Projections.constructor(StudyBoardDetails.class,
                         studyBoard.id,
@@ -66,7 +67,8 @@ public class StudyBoardRepositoryCustomImpl implements StudyBoardRepositoryCusto
                         studyBoard.createdAt,
                         studyBoard.updatedAt,
                         studyApply.id.member.count().intValue(),
-                        Expressions.constant(viewType)))
+                        Expressions.constant(viewType),
+                        Expressions.constant(isAlreadyApplied)))
                 .from(studyBoard)
                 .leftJoin(studyApply)
                 .on(hasMatchingStudyBoardId(studyApply.id.studyBoard.id))

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
@@ -11,11 +11,10 @@ import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.study.dto.CreateStudyBoardRequest;
 import com.dongsoop.dongsoop.recruitment.study.dto.StudyBoardDetails;
 import com.dongsoop.dongsoop.recruitment.study.dto.StudyBoardOverview;
-import com.dongsoop.dongsoop.recruitment.study.entity.StudyApply.StudyApplyKey;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoard;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoardDepartment;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoardDepartment.StudyBoardDepartmentId;
-import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepository;
+import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardRepositoryCustom;
@@ -39,7 +38,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
 
     private final StudyBoardDepartmentRepository studyBoardDepartmentRepository;
 
-    private final StudyApplyRepository studyApplyRepository;
+    private final StudyApplyRepositoryCustom studyApplyRepositoryCustom;
 
     @Transactional
     public StudyBoard create(CreateStudyBoardRequest request) {
@@ -74,9 +73,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            StudyBoard board = studyBoardRepository.getReferenceById(boardId);
-            StudyApplyKey applyKey = new StudyApplyKey(board, member);
-            boolean isAlreadyApplied = studyApplyRepository.existsById(applyKey);
+            boolean isAlreadyApplied = studyApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
@@ -73,7 +73,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = studyApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
+            boolean isAlreadyApplied = studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, member.getId());
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyBoardServiceImpl.java
@@ -3,7 +3,7 @@ package com.dongsoop.dongsoop.recruitment.study.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
-import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
+import com.dongsoop.dongsoop.exception.domain.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.exception.domain.study.StudyBoardNotFound;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -67,16 +67,16 @@ public class StudyBoardServiceImpl implements StudyBoardService {
 
     public StudyBoardDetails getBoardDetailsById(Long boardId) {
         try {
-            Member member = memberService.getMemberReferenceByContext();
-            boolean isOwner = studyBoardRepository.existsByIdAndAuthor(boardId, member);
+            Long memberId = memberService.getMemberIdByAuthentication();
+            boolean isOwner = studyBoardRepository.existsByIdAndAuthorId(boardId, memberId);
             if (isOwner) {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, member.getId());
+            boolean isAlreadyApplied = studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, memberId);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
-        } catch (MemberNotFoundException exception) {
+        } catch (NotAuthenticationException exception) {
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.GUEST);
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/dto/TutoringBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/dto/TutoringBoardDetails.java
@@ -18,12 +18,14 @@ public record TutoringBoardDetails(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         Integer volunteer,
-        RecruitmentViewType viewType
+        RecruitmentViewType viewType,
+        boolean isAlreadyApplied
 ) {
     public TutoringBoardDetails(Long id, String title, String content, String tags, LocalDateTime startAt,
                                 LocalDateTime endAt, DepartmentType departmentType, String author,
                                 LocalDateTime createdAt,
-                                LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType) {
+                                LocalDateTime updatedAt, Integer volunteer, RecruitmentViewType viewType,
+                                boolean isAlreadyApplied) {
         this(
                 id,
                 title,
@@ -36,7 +38,8 @@ public record TutoringBoardDetails(
                 createdAt,
                 updatedAt,
                 volunteer,
-                viewType
+                viewType,
+                isAlreadyApplied
         );
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
@@ -1,8 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
-
 public interface TutoringApplyRepositoryCustom {
 
-    boolean existsByBoardIdAndMember(Long boardId, Member member);
+    boolean existsByBoardIdAndMemberId(Long boardId, Long member);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dongsoop.dongsoop.recruitment.tutoring.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+
+public interface TutoringApplyRepositoryCustom {
+
+    boolean existsByBoardIdAndMember(Long boardId, Member member);
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.dongsoop.dongsoop.recruitment.tutoring.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositoryCustom {
+
+    private static final QTutoringApply tutoringApply = QTutoringApply.tutoringApply;
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+        return queryFactory.selectOne()
+                .from(tutoringApply)
+                .where(tutoringApply.id.tutoringBoard.id.eq(boardId)
+                        .and(tutoringApply.id.member.eq(member)))
+                .fetchFirst() != null;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +13,11 @@ public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositor
 
     private final JPAQueryFactory queryFactory;
 
-    public boolean existsByBoardIdAndMember(Long boardId, Member member) {
+    public boolean existsByBoardIdAndMemberId(Long boardId, Long memberId) {
         return queryFactory.selectOne()
                 .from(tutoringApply)
                 .where(tutoringApply.id.tutoringBoard.id.eq(boardId)
-                        .and(tutoringApply.id.member.eq(member)))
+                        .and(tutoringApply.id.member.id.eq(memberId)))
                 .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepository.java
@@ -1,10 +1,9 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
-import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TutoringBoardRepository extends JpaRepository<TutoringBoard, Long> {
 
-    boolean existsByIdAndAuthor(Long id, Member author);
+    boolean existsByIdAndAuthorId(Long id, Long authorId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustom.java
@@ -15,5 +15,7 @@ public interface TutoringBoardRepositoryCustom {
 
     List<TutoringBoardOverview> findTutoringBoardOverviewsByPage(Pageable pageable);
 
-    Optional<TutoringBoardDetails> findBoardDetailsByIdAndViewType(Long tutoringBoardId, RecruitmentViewType viewType);
+    Optional<TutoringBoardDetails> findBoardDetailsByIdAndViewType(Long tutoringBoardId,
+                                                                   RecruitmentViewType viewType,
+                                                                   boolean isAlreadyApplied);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringBoardRepositoryCustomImpl.java
@@ -51,7 +51,8 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
     }
 
     public Optional<TutoringBoardDetails> findBoardDetailsByIdAndViewType(Long tutoringBoardId,
-                                                                          RecruitmentViewType viewType) {
+                                                                          RecruitmentViewType viewType,
+                                                                          boolean isAlreadyApplied) {
         return Optional.ofNullable(
                 queryFactory.select(Projections.constructor(TutoringBoardDetails.class,
                                 tutoringBoard.id,
@@ -65,8 +66,8 @@ public class TutoringBoardRepositoryCustomImpl implements TutoringBoardRepositor
                                 tutoringBoard.createdAt.as("createdAt"),
                                 tutoringBoard.updatedAt.as("updatedAt"),
                                 tutoringApplication.id.member.count().intValue(),
-                                Expressions.constant(viewType)
-                        ))
+                                Expressions.constant(viewType),
+                                Expressions.constant(isAlreadyApplied)))
                         .from(tutoringBoard)
                         .leftJoin(tutoringApplication)
                         .on(tutoringApplication.id.tutoringBoard.id.eq(tutoringBoard.id))

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
@@ -11,9 +11,8 @@ import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.CreateTutoringBoardRequest;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardDetails;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.TutoringBoardOverview;
-import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringApply.TutoringApplyKey;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringBoard;
-import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringApplyRepository;
+import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringBoardRepository;
 import com.dongsoop.dongsoop.recruitment.tutoring.repository.TutoringBoardRepositoryCustom;
 import java.util.List;
@@ -29,7 +28,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final TutoringBoardRepositoryCustom tutoringBoardRepositoryCustom;
 
-    private final TutoringApplyRepository tutoringApplyRepository;
+    private final TutoringApplyRepositoryCustom tutoringApplyRepositoryCustom;
 
     private final DepartmentRepository departmentRepository;
 
@@ -58,9 +57,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            TutoringBoard board = tutoringBoardRepository.getReferenceById(boardId);
-            TutoringApplyKey applyKey = new TutoringApplyKey(board, member);
-            boolean isAlreadyApplied = tutoringApplyRepository.existsById(applyKey);
+            boolean isAlreadyApplied = tutoringApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
@@ -57,7 +57,8 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = tutoringApplyRepositoryCustom.existsByBoardIdAndMember(boardId, member);
+            boolean isAlreadyApplied = tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId,
+                    member.getId());
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
         } catch (MemberNotFoundException exception) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringBoardServiceImpl.java
@@ -3,7 +3,7 @@ package com.dongsoop.dongsoop.recruitment.tutoring.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
-import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
+import com.dongsoop.dongsoop.exception.domain.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.exception.domain.tutoring.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -51,17 +51,16 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     public TutoringBoardDetails getBoardDetailsById(Long boardId) {
         try {
-            Member member = memberService.getMemberReferenceByContext();
-            boolean isOwner = tutoringBoardRepository.existsByIdAndAuthor(boardId, member);
+            Long memberId = memberService.getMemberIdByAuthentication();
+            boolean isOwner = tutoringBoardRepository.existsByIdAndAuthorId(boardId, memberId);
             if (isOwner) {
                 return getBoardDetailsWithViewType(boardId, RecruitmentViewType.OWNER);
             }
 
-            boolean isAlreadyApplied = tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId,
-                    member.getId());
+            boolean isAlreadyApplied = tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, memberId);
 
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.MEMBER, isAlreadyApplied);
-        } catch (MemberNotFoundException exception) {
+        } catch (NotAuthenticationException exception) {
             return getBoardDetailsWithViewType(boardId, RecruitmentViewType.GUEST);
         }
     }


### PR DESCRIPTION
## 구현 내용

모집 게시글 상세페이지 접근 시 지원 여부에 따라 버튼 상태를 달리 하기 위한 구현  
아래와 같이 게시판, 사용자 레퍼런스 엔티티를 통해 존재 여부 확인 후 응답에 포함

```java
StudyBoard board = studyBoardRepository.getReferenceById(boardId);
StudyApplyKey applyKey = new StudyApplyKey(board, member);
boolean isAlreadyApplied = studyApplyRepository.existsById(applyKey);
```

\+ 중복 지원 시 오류를 반환합니다. - 400 Bad Request