### PR TITLE
시간표 기능 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.date;
 
+import com.dongsoop.dongsoop.exception.domain.date.TimeTypeMismatchException;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.Field;
@@ -51,6 +52,6 @@ public class EndAtAfterStartAtValidator implements ConstraintValidator<EndAtAfte
             return endAt.isAfter(startAt);
         }
 
-        return false;
+        throw new TimeTypeMismatchException();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/date/EndAtAfterStartAtValidator.java
@@ -4,6 +4,7 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -28,16 +29,28 @@ public class EndAtAfterStartAtValidator implements ConstraintValidator<EndAtAfte
             startField.setAccessible(true);
             endField.setAccessible(true);
 
-            LocalDateTime startAt = (LocalDateTime) startField.get(object);
-            LocalDateTime endAt = (LocalDateTime) endField.get(object);
-            if (startAt == null || endAt == null) {
+            Object startAtObject = startField.get(object);
+            Object endAtObject = endField.get(object);
+            if (startAtObject == null || endAtObject == null) {
                 return true; // null 검증은 @NotNull 에서 처리
             }
 
-            return endAt.isAfter(startAt);
+            return compare(startAtObject, endAtObject);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return false;
         }
+    }
+
+    private boolean compare(Object startAtObject, Object endAtObject) {
+        if (endAtObject instanceof LocalDateTime endAt && startAtObject instanceof LocalDateTime startAt) {
+            return endAt.isAfter(startAt);
+        }
+
+        if (endAtObject instanceof LocalTime endAt && startAtObject instanceof LocalTime startAt) {
+            return endAt.isAfter(startAt);
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/date/TimeTypeMismatchException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/date/TimeTypeMismatchException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.date;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TimeTypeMismatchException extends CustomException {
+
+    public TimeTypeMismatchException() {
+        super("두 날짜 또는 시간 변수의 타입이 올바르지 않습니다", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.exception.domain.timetable;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TimetableNotFoundException extends CustomException {
+
+    public TimetableNotFoundException(Long timetableId) {
+        super("존재하지 않는 시간표 ID입니다: " + timetableId, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableNotOwnedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableNotOwnedException.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.exception.domain.timetable;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TimetableNotOwnedException extends CustomException {
+
+    public TimetableNotOwnedException(Long timetableId, Long memberId) {
+        super("사용자의 시간표가 아닙니다. 시간표 id: " + timetableId + ", 사용자 ID: " + memberId,
+                HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableOverlapException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/timetable/TimetableOverlapException.java
@@ -1,0 +1,16 @@
+package com.dongsoop.dongsoop.exception.domain.timetable;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import java.time.LocalTime;
+import org.springframework.http.HttpStatus;
+
+public class TimetableOverlapException extends CustomException {
+
+    public TimetableOverlapException(LocalTime startAt, LocalTime endAt, LocalTime overlapStartAt,
+                                     LocalTime overlapEndAt) {
+        super("겹치는 시간표가 존재합니다.\n"
+                        + "[요청된 시간] 시작 시간: " + startAt + ", 종료 시간: " + endAt + "\n"
+                        + "[저장된 시간] 시작 시간: " + overlapStartAt + ", 종료 시간: " + overlapEndAt,
+                HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -1,0 +1,43 @@
+package com.dongsoop.dongsoop.timetable.controller;
+
+import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
+import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import com.dongsoop.dongsoop.timetable.service.TimetableService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.time.Year;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/timetable")
+public class TimetableController {
+
+    private final TimetableService timetableService;
+
+    @GetMapping("/{year}/{semester}")
+    public ResponseEntity<List<TimetableView>> getTimetable(@PathVariable("year") Year year,
+                                                            @PathVariable("semester") SemesterType semester) {
+        List<TimetableView> timetable = timetableService.getTimetableView(year, semester);
+
+        return ResponseEntity.ok(timetable);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createTimetable(@RequestBody @Valid CreateTimetableRequest request) {
+        timetableService.createTimetable(request);
+        URI uri = URI.create("/timetable/" + request.year() + "/" + request.semester());
+
+        return ResponseEntity.created(uri)
+                .build();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.timetable.controller;
 
+import com.dongsoop.dongsoop.role.entity.RoleType;
 import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
 import com.dongsoop.dongsoop.timetable.dto.TimetableView;
 import com.dongsoop.dongsoop.timetable.entity.SemesterType;
@@ -10,6 +11,7 @@ import java.time.Year;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +36,7 @@ public class TimetableController {
     }
 
     @PostMapping
+    @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> createTimetable(@RequestBody @Valid CreateTimetableRequest request) {
         timetableService.createTimetable(request);
         URI uri = URI.create("/timetable/" + request.year() + "/" + request.semester());
@@ -43,6 +46,7 @@ public class TimetableController {
     }
 
     @DeleteMapping("/{timetableId}")
+    @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> deleteTimetable(@PathVariable("timetableId") Long timetableId) {
         timetableService.deleteTimetable(timetableId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -10,6 +10,7 @@ import java.time.Year;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,5 +40,11 @@ public class TimetableController {
 
         return ResponseEntity.created(uri)
                 .build();
+    }
+
+    @DeleteMapping("/{timetableId}")
+    public ResponseEntity<Void> deleteTimetable(@PathVariable("timetableId") Long timetableId) {
+        timetableService.deleteTimetable(timetableId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.timetable.controller;
 import com.dongsoop.dongsoop.role.entity.RoleType;
 import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
 import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.dto.UpdateTimetableRequest;
 import com.dongsoop.dongsoop.timetable.entity.SemesterType;
 import com.dongsoop.dongsoop.timetable.service.TimetableService;
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +51,13 @@ public class TimetableController {
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> deleteTimetable(@PathVariable("timetableId") Long timetableId) {
         timetableService.deleteTimetable(timetableId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<Void> updateTimetable(@RequestBody @Valid UpdateTimetableRequest request) {
+        timetableService.updateTimetable(request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/CreateTimetableRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/CreateTimetableRequest.java
@@ -1,0 +1,40 @@
+package com.dongsoop.dongsoop.timetable.dto;
+
+import com.dongsoop.dongsoop.date.EndAtAfterStartAt;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.Year;
+import org.hibernate.validator.constraints.Length;
+
+@EndAtAfterStartAt
+public record CreateTimetableRequest(
+
+        @NotBlank(message = "이름은 필수 입력값입니다.")
+        @Length(max = 15, message = "이름은 최대 15자까지 입력할 수 있습니다.")
+        String name,
+
+        @Length(max = 8, message = "교수 이름은 최대 8자까지 입력할 수 있습니다.")
+        String professor,
+
+        @Length(max = 10, message = "위치는 최대 10자까지 입력할 수 있습니다.")
+        String location,
+
+        @NotNull(message = "요일은 필수 입력값입니다.")
+        DayOfWeek week,
+
+        @NotNull(message = "시작 시간은 필수 입력값입니다.")
+        LocalTime startAt,
+
+        @NotNull(message = "종료 시간은 필수 입력값입니다.")
+        LocalTime endAt,
+
+        @NotNull(message = "학기 연도는 필수 입력값입니다.")
+        Year year,
+
+        @NotNull(message = "학기 유형은 필수 입력값입니다.")
+        SemesterType semester
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/OverlapTimetable.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/OverlapTimetable.java
@@ -1,0 +1,9 @@
+package com.dongsoop.dongsoop.timetable.dto;
+
+import java.time.LocalTime;
+
+public record OverlapTimetable(
+        LocalTime startAt,
+        LocalTime endAt
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/TimetableView.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/TimetableView.java
@@ -1,0 +1,16 @@
+package com.dongsoop.dongsoop.timetable.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record TimetableView(
+
+        Long id,
+        String name,
+        String professor,
+        String location,
+        LocalTime startAt,
+        LocalTime endAt,
+        DayOfWeek week
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/UpdateTimetableRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/UpdateTimetableRequest.java
@@ -1,0 +1,26 @@
+package com.dongsoop.dongsoop.timetable.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import org.hibernate.validator.constraints.Length;
+
+public record UpdateTimetableRequest(
+
+        @NotNull
+        Long id,
+
+        @Length(max = 15, message = "이름은 최대 15자까지 입력할 수 있습니다.")
+        String name,
+
+        @Length(max = 8, message = "교수 이름은 최대 8자까지 입력할 수 있습니다.")
+        String professor,
+
+        @Length(max = 10, message = "위치는 최대 10자까지 입력할 수 있습니다.")
+        String location,
+
+        DayOfWeek week,
+        LocalTime startAt,
+        LocalTime endAt
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/YearSemester.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/YearSemester.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.timetable.dto;
+
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import java.time.Year;
+
+public interface YearSemester {
+
+    Year getYear();
+
+    SemesterType getSemester();
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/entity/SemesterType.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/entity/SemesterType.java
@@ -1,0 +1,9 @@
+package com.dongsoop.dongsoop.timetable.entity;
+
+public enum SemesterType {
+
+    FIRST,
+    SECOND,
+    SUMMER,
+    WINTER
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
@@ -1,0 +1,61 @@
+package com.dongsoop.dongsoop.timetable.entity;
+
+import com.dongsoop.dongsoop.common.BaseEntity;
+import com.dongsoop.dongsoop.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.Year;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@SequenceGenerator(name = "timetable_sequence_generator")
+@SQLRestriction("is_deleted = false")
+public class Timetable extends BaseEntity {
+
+    @Id
+    @GeneratedValue(generator = "timetable_sequence_generator")
+    private Long id;
+
+    @Column(name = "name", length = 15, nullable = false)
+    private String name;
+
+    @Column(name = "professor", length = 8)
+    private String professor;
+
+    @Column(name = "location", length = 10)
+    private String location;
+
+    @Column(name = "week", nullable = false)
+    private DayOfWeek week;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalTime endAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "year", nullable = false)
+    private Year year;
+
+    @Column(name = "semester", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SemesterType semester;
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.timetable.entity;
 
 import com.dongsoop.dongsoop.common.BaseEntity;
 import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.timetable.dto.UpdateTimetableRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -51,13 +52,39 @@ public class Timetable extends BaseEntity {
     private LocalTime endAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
-    @Column(name = "year", nullable = false)
+    @Column(name = "year", nullable = false, updatable = false)
     private Year year;
 
-    @Column(name = "semester", nullable = false)
+    @Column(name = "semester", nullable = false, updatable = false)
     @Enumerated(EnumType.STRING)
     private SemesterType semester;
+
+    public void update(UpdateTimetableRequest request) {
+        if (request.name() != null) {
+            this.name = request.name();
+        }
+
+        if (request.professor() != null) {
+            this.professor = request.professor();
+        }
+
+        if (request.location() != null) {
+            this.location = request.location();
+        }
+
+        if (request.week() != null) {
+            this.week = request.week();
+        }
+
+        if (request.startAt() != null) {
+            this.startAt = request.startAt();
+        }
+
+        if (request.endAt() != null) {
+            this.endAt = request.endAt();
+        }
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/entity/Timetable.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
 import java.time.Year;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -24,6 +25,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor
 @SequenceGenerator(name = "timetable_sequence_generator")
 @SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE timetable SET is_deleted = true WHERE id = ?")
 public class Timetable extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepository.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.timetable.repository;
 
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.dto.YearSemester;
 import com.dongsoop.dongsoop.timetable.entity.SemesterType;
 import com.dongsoop.dongsoop.timetable.entity.Timetable;
 import java.time.Year;
@@ -11,4 +12,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
 
     List<TimetableView> findAllByMemberAndYearAndSemester(Member member, Year year, SemesterType semester);
+
+    YearSemester findYearSemesterById(Long id);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepository.java
@@ -1,0 +1,14 @@
+package com.dongsoop.dongsoop.timetable.repository;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import com.dongsoop.dongsoop.timetable.entity.Timetable;
+import java.time.Year;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+
+    List<TimetableView> findAllByMemberAndYearAndSemester(Member member, Year year, SemesterType semester);
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
@@ -13,4 +13,9 @@ public interface TimetableRepositoryCustom {
                                                       LocalTime startAt, LocalTime endAt);
 
     boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    Optional<OverlapTimetable> findOverlapWithinRangeExcludingSelf(Long timetableId, Long memberId, Year year,
+                                                                   SemesterType semester,
+                                                                   DayOfWeek week,
+                                                                   LocalTime startAt, LocalTime endAt);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.dongsoop.dongsoop.timetable.repository;
+
+import com.dongsoop.dongsoop.timetable.dto.OverlapTimetable;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.Year;
+import java.util.Optional;
+
+public interface TimetableRepositoryCustom {
+
+    Optional<OverlapTimetable> findOverlapWithinRange(Long memberId, Year year, SemesterType semester, DayOfWeek week,
+                                                      LocalTime startAt, LocalTime endAt);
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface TimetableRepositoryCustom {
 
     Optional<OverlapTimetable> findOverlapWithinRange(Long memberId, Year year, SemesterType semester, DayOfWeek week,
                                                       LocalTime startAt, LocalTime endAt);
+
+    boolean existsByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -43,4 +43,12 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
                 .or(timetable.endAt.between(startAt, endAt))
                 .or(timetable.startAt.loe(startAt).and(timetable.endAt.goe(endAt)));
     }
+
+    public boolean existsByIdAndMemberId(Long id, Long memberId) {
+        return queryFactory
+                .selectFrom(timetable)
+                .where(timetable.id.eq(id)
+                        .and(timetable.member.id.eq(memberId)))
+                .fetchOne() != null;
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -1,0 +1,46 @@
+package com.dongsoop.dongsoop.timetable.repository;
+
+import com.dongsoop.dongsoop.timetable.dto.OverlapTimetable;
+import com.dongsoop.dongsoop.timetable.entity.QTimetable;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.Year;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom {
+
+    private static final QTimetable timetable = QTimetable.timetable;
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<OverlapTimetable> findOverlapWithinRange(Long memberId, Year year, SemesterType semester,
+                                                             DayOfWeek week,
+                                                             LocalTime startAt, LocalTime endAt) {
+        OverlapTimetable result = queryFactory
+                .select(Projections.constructor(OverlapTimetable.class,
+                        timetable.startAt, timetable.endAt))
+                .from(timetable)
+                .where(timetable.semester.eq(semester)
+                        .and(timetable.year.eq(year))
+                        .and(timetable.member.id.eq(memberId))
+                        .and(timetable.week.eq(week))
+                        .and(validateOverlap(startAt, endAt)))
+                .fetchFirst();
+
+        return Optional.ofNullable(result);
+    }
+
+    private BooleanExpression validateOverlap(LocalTime startAt, LocalTime endAt) {
+        return timetable.startAt.between(startAt, endAt)
+                .or(timetable.endAt.between(startAt, endAt))
+                .or(timetable.startAt.loe(startAt).and(timetable.endAt.goe(endAt)));
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -39,9 +39,9 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
     }
 
     private BooleanExpression validateOverlap(LocalTime startAt, LocalTime endAt) {
-        return timetable.startAt.between(startAt, endAt)
-                .or(timetable.endAt.between(startAt, endAt))
-                .or(timetable.startAt.loe(startAt).and(timetable.endAt.goe(endAt)));
+        return timetable.startAt.gt(startAt).and(timetable.startAt.lt(endAt))
+                .or(timetable.endAt.gt(startAt).and(timetable.startAt.lt(endAt)))
+                .or(timetable.startAt.lt(startAt).and(timetable.endAt.gt(endAt)));
     }
 
     public boolean existsByIdAndMemberId(Long id, Long memberId) {

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -51,4 +51,23 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
                         .and(timetable.member.id.eq(memberId)))
                 .fetchOne() != null;
     }
+
+    public Optional<OverlapTimetable> findOverlapWithinRangeExcludingSelf(Long timetableId, Long memberId, Year year,
+                                                                          SemesterType semester,
+                                                                          DayOfWeek week,
+                                                                          LocalTime startAt, LocalTime endAt) {
+        OverlapTimetable result = queryFactory
+                .select(Projections.constructor(OverlapTimetable.class,
+                        timetable.startAt, timetable.endAt))
+                .from(timetable)
+                .where(timetable.semester.eq(semester)
+                        .and(timetable.year.eq(year))
+                        .and(timetable.member.id.eq(memberId))
+                        .and(timetable.week.eq(week))
+                        .and(validateOverlap(startAt, endAt))
+                        .and(timetable.id.ne(timetableId)))
+                .fetchFirst();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -39,9 +39,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
     }
 
     private BooleanExpression validateOverlap(LocalTime startAt, LocalTime endAt) {
-        return timetable.startAt.gt(startAt).and(timetable.startAt.lt(endAt))
-                .or(timetable.endAt.gt(startAt).and(timetable.startAt.lt(endAt)))
-                .or(timetable.startAt.lt(startAt).and(timetable.endAt.gt(endAt)));
+        return timetable.startAt.lt(endAt).and(timetable.endAt.gt(startAt));
     }
 
     public boolean existsByIdAndMemberId(Long id, Long memberId) {

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableMapper.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableMapper.java
@@ -1,0 +1,31 @@
+package com.dongsoop.dongsoop.timetable.service;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
+import com.dongsoop.dongsoop.timetable.entity.Timetable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TimetableMapper {
+
+    private final MemberService memberService;
+
+    public Timetable toEntity(CreateTimetableRequest request) {
+        Member referenceMember = memberService.getMemberReferenceByContext();
+
+        return Timetable.builder()
+                .name(request.name())
+                .professor(request.professor())
+                .location(request.location())
+                .week(request.week())
+                .startAt(request.startAt())
+                .endAt(request.endAt())
+                .year(request.year())
+                .semester(request.semester())
+                .member(referenceMember)
+                .build();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
@@ -11,4 +11,6 @@ public interface TimetableService {
     void createTimetable(CreateTimetableRequest request);
 
     List<TimetableView> getTimetableView(Year year, SemesterType semester);
+
+    void deleteTimetable(Long timetableId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.timetable.service;
 
 import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
 import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.dto.UpdateTimetableRequest;
 import com.dongsoop.dongsoop.timetable.entity.SemesterType;
 import java.time.Year;
 import java.util.List;
@@ -13,4 +14,6 @@ public interface TimetableService {
     List<TimetableView> getTimetableView(Year year, SemesterType semester);
 
     void deleteTimetable(Long timetableId);
+
+    void updateTimetable(UpdateTimetableRequest request);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
@@ -1,0 +1,14 @@
+package com.dongsoop.dongsoop.timetable.service;
+
+import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
+import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import java.time.Year;
+import java.util.List;
+
+public interface TimetableService {
+
+    void createTimetable(CreateTimetableRequest request);
+
+    List<TimetableView> getTimetableView(Year year, SemesterType semester);
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
@@ -1,0 +1,61 @@
+package com.dongsoop.dongsoop.timetable.service;
+
+import com.dongsoop.dongsoop.exception.domain.timetable.TimetableOverlapException;
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.timetable.dto.CreateTimetableRequest;
+import com.dongsoop.dongsoop.timetable.dto.OverlapTimetable;
+import com.dongsoop.dongsoop.timetable.dto.TimetableView;
+import com.dongsoop.dongsoop.timetable.entity.SemesterType;
+import com.dongsoop.dongsoop.timetable.entity.Timetable;
+import com.dongsoop.dongsoop.timetable.repository.TimetableRepository;
+import com.dongsoop.dongsoop.timetable.repository.TimetableRepositoryCustom;
+import java.time.Year;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TimetableServiceImpl implements TimetableService {
+
+    private final TimetableRepository timetableRepository;
+
+    private final TimetableRepositoryCustom timetableRepositoryCustom;
+
+    private final MemberService memberService;
+
+    private final TimetableMapper timetableMapper;
+
+    public void createTimetable(CreateTimetableRequest request) {
+        Timetable timetable = timetableMapper.toEntity(request);
+
+        validateOverlapTimetable(request);
+
+        timetableRepository.save(timetable);
+    }
+
+    public List<TimetableView> getTimetableView(Year year, SemesterType semester) {
+        Member referenceMember = memberService.getMemberReferenceByContext();
+        return timetableRepository.findAllByMemberAndYearAndSemester(referenceMember,
+                year, semester);
+    }
+
+    private void validateOverlapTimetable(CreateTimetableRequest request) {
+        Long memberId = memberService.getMemberIdByAuthentication();
+
+        Optional<OverlapTimetable> optionalOverlapTimetable = timetableRepositoryCustom.findOverlapWithinRange(
+                memberId,
+                request.year(),
+                request.semester(),
+                request.week(),
+                request.startAt(),
+                request.endAt());
+
+        optionalOverlapTimetable.ifPresent(overlapTimetable -> {
+            throw new TimetableOverlapException(request.startAt(), request.endAt(), overlapTimetable.startAt(),
+                    overlapTimetable.endAt());
+        });
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.timetable.service;
 
+import com.dongsoop.dongsoop.exception.domain.timetable.TimetableNotOwnedException;
 import com.dongsoop.dongsoop.exception.domain.timetable.TimetableOverlapException;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -57,5 +58,15 @@ public class TimetableServiceImpl implements TimetableService {
             throw new TimetableOverlapException(request.startAt(), request.endAt(), overlapTimetable.startAt(),
                     overlapTimetable.endAt());
         });
+    }
+
+    public void deleteTimetable(Long timetableId) {
+        Long memberId = memberService.getMemberIdByAuthentication();
+        boolean isRequesterIsOwner = timetableRepositoryCustom.existsByIdAndMemberId(timetableId, memberId);
+        if (!isRequesterIsOwner) { // 요청자가 소유자가 아닌 경우
+            throw new TimetableNotOwnedException(timetableId, memberId);
+        }
+
+        timetableRepository.deleteById(timetableId);
     }
 }


### PR DESCRIPTION
Close #85 

## 기능 설명(Description)

사용자의 학업 시간표를 생성/읽기/수정/삭제가 가능하다.

## 구현해야 할 세부 항목(Tasks/Checklist)

- [x] 시간표 생성
   - 이름
   - 교수명
   - 장소
   - 요일
   - 시작시간
   - 종료시간
   - 학기 
- [x] 시간표 읽기
   - 사용자 ID, 연도, 학과 일치여부
- [x] 시간표 수정
   - [x] 요청자 ID와 시간표 데이터 주인 ID 검증
- [x] 시간표 삭제
   - [x] 요청자 ID와 시간표 데이터 주인 ID 검증

> [!NOTE]
> GET
> /timetable/{year}/{semester}
> 특정 연도 및 학기의 시간표 조회
> 200 OK

response

```json
[
    {
        "id": 1,
        "name": "이름",
        "professor": "교수명",
        "location": "지역",
        "startAt": "10:00:00",
        "endAt": "12:00:00",
        "week": "SATURDAY"
    },
    {
        "id": 2,
        "name": "수정 이름",
        "professor": "수정된 교수명",
        "location": "수정된 지역",
        "startAt": "20:00:00",
        "endAt": "22:00:00",
        "week": "SATURDAY"
    }
]
```

> [!NOTE]
> POST
> /timetable
> 시간표 생성
> 201 Created

request

```json
{
    "name": "테스트이름",
    "professor": "교수명",
    "location": "지역명",
    "week": 1,
    "startAt": "08:00:00",
    "endAt": "10:00:00",
    "year": 2025,
    "semester": "FIRST"
}
```

> [!NOTE]
> DELETE
> /timetable/{timetableId}
> 시간표 삭제
> 204 NoContent


> [!NOTE]
> PATCH
> /timetable
> 시간표 수정
> 204 NoContent

request

```json
{
    "id": 1,
    "name": "수정 이름",
    "professor": "수정된 교수명",
    "location": "수정된 지역",
    "week": 5,
    "startAt": "20:00:00",
    "endAt": "22:00:00"
}
```