### PR TITLE
이메일 및 닉네임 유효성 검사

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/exception/domain/member/NicknameDuplicatedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/exception/domain/member/NicknameDuplicatedException.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.exception.domain.member;
+
+import com.dongsoop.dongsoop.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NicknameDuplicatedException extends CustomException {
+
+    public NicknameDuplicatedException() {
+        super("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT);
+    }
+
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.dongsoop.dongsoop.member.dto.EmailValidateRequest;
 import com.dongsoop.dongsoop.member.dto.LoginDetails;
 import com.dongsoop.dongsoop.member.dto.LoginRequest;
 import com.dongsoop.dongsoop.member.dto.LoginResponse;
+import com.dongsoop.dongsoop.member.dto.NicknameValidateRequest;
 import com.dongsoop.dongsoop.member.dto.SignupRequest;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -45,6 +46,13 @@ public class MemberController {
     @PostMapping("/validate/email")
     public ResponseEntity<Void> validateEmail(@RequestBody @Valid EmailValidateRequest request) {
         memberService.checkEmailDuplication(request.email());
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PostMapping("/validate/nickname")
+    public ResponseEntity<Void> validateNickname(@RequestBody @Valid NicknameValidateRequest request) {
+        memberService.checkNicknameDuplication(request.nickname());
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.member.controller;
 
 import com.dongsoop.dongsoop.jwt.dto.IssuedToken;
+import com.dongsoop.dongsoop.member.dto.EmailValidateRequest;
 import com.dongsoop.dongsoop.member.dto.LoginDetails;
 import com.dongsoop.dongsoop.member.dto.LoginRequest;
 import com.dongsoop.dongsoop.member.dto.LoginResponse;
@@ -39,5 +40,12 @@ public class MemberController {
 
         LoginResponse loginResponse = new LoginResponse(loginDetail.getLoginMemberDetail(), accessToken, refreshToken);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/validate/email")
+    public ResponseEntity<Void> validateEmail(@RequestBody @Valid EmailValidateRequest request) {
+        memberService.checkEmailDuplication(request.email());
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/dto/EmailValidateRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/dto/EmailValidateRequest.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailValidateRequest(
+
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Pattern(regexp = "@dongyang.ac.kr$", message = "이메일은 동양미래대학교 이메일 형식이어야 합니다.")
+        String email
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/dto/EmailValidateRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/dto/EmailValidateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern;
 public record EmailValidateRequest(
 
         @NotBlank(message = "이메일은 필수 입력값입니다.")
-        @Pattern(regexp = "@dongyang.ac.kr$", message = "이메일은 동양미래대학교 이메일 형식이어야 합니다.")
+        @Pattern(regexp = "[A-Za-z0-9]+@dongyang.ac.kr$", message = "이메일은 동양미래대학교 이메일 형식이어야 합니다.")
         String email
 ) {
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/dto/NicknameValidateRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/dto/NicknameValidateRequest.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record NicknameValidateRequest(
+
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Length(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
@@ -2,9 +2,8 @@ package com.dongsoop.dongsoop.member.repository;
 
 import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
 import com.dongsoop.dongsoop.member.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<LoginAuthenticate> findLoginAuthenticateByEmail(String email);
@@ -12,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<LoginAuthenticate> findLoginAuthenticateByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -21,4 +21,6 @@ public interface MemberService {
     Long getMemberIdByAuthentication();
 
     void checkEmailDuplication(String email);
+
+    void checkNicknameDuplication(String nickname);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -19,4 +19,6 @@ public interface MemberService {
     String getNicknameById(Long userId);
 
     Long getMemberIdByAuthentication();
+
+    void checkEmailDuplication(String email);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.dongsoop.dongsoop.exception.domain.authentication.NotAuthenticationEx
 import com.dongsoop.dongsoop.exception.domain.member.EmailDuplicatedException;
 import com.dongsoop.dongsoop.exception.domain.member.InvalidPasswordFormatException;
 import com.dongsoop.dongsoop.exception.domain.member.MemberNotFoundException;
+import com.dongsoop.dongsoop.exception.domain.member.NicknameDuplicatedException;
 import com.dongsoop.dongsoop.jwt.TokenGenerator;
 import com.dongsoop.dongsoop.jwt.dto.IssuedToken;
 import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
@@ -56,6 +57,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public void signup(SignupRequest request) {
         checkEmailDuplication(request.getEmail());
+        checkNicknameDuplication(request.getNickname());
 
         Member member = transformToMemberBySignupRequest(request);
         memberRepository.save(member);
@@ -143,6 +145,14 @@ public class MemberServiceImpl implements MemberService {
     private void validatePassword(String loginPassword, String password) {
         if (!passwordEncoder.matches(loginPassword, password)) {
             throw new InvalidPasswordFormatException();
+        }
+    }
+
+    public void checkNicknameDuplication(String nickname) {
+        boolean isExists = memberRepository.existsByNickname(nickname);
+
+        if (isExists) {
+            throw new NicknameDuplicatedException();
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -146,7 +146,7 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
-    private void checkEmailDuplication(String email) {
+    public void checkEmailDuplication(String email) {
         boolean isExists = memberRepository.existsByEmail(email);
 
         if (isExists) {


### PR DESCRIPTION
회원 가입 단계에서 사용자의 이메일 및 닉네임을 미리 검사 후 가입할 수 있도록 별도 API 분리