### PR TITLE
활동 중인 채팅방에 새로 초대된 사용자 판단 기능 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -9,7 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -284,10 +287,10 @@ public class ChatService {
 
         boolean shouldCreateEnterMessage = isFirstTimeEntry(roomId, userId);
 
-        return Optional.of(shouldCreateEnterMessage)
-                .filter(Boolean::booleanValue)
-                .map(b -> createAndSaveSystemMessage(roomId, userId, MessageType.ENTER))
-                .orElse(null);
+        if (shouldCreateEnterMessage) {
+            return createAndSaveSystemMessage(roomId, userId, MessageType.ENTER);
+        }
+        return null;
     }
 
     private boolean isNewInvitedUser(String roomId, ChatRoom room, Long userId, LocalDateTime userJoinTime) {


### PR DESCRIPTION
#왜 필요한가?
변경전 로직에서는 채팅방 개설 시 초기 참가자의 입장에 대한 시스템 메세지를 반환하는데, 
현재 발견된 문제는 활동중인 채팅방에 새로운 참가자를 초대한뒤 입장시에 enter메세지와 사용자 입장을 알리는 id값을 반환 되어야 정상적인 로직인데 해당 기능이 정상적으로 동작하지않아 수정 및 추가하였습니다.



## isNewInvitedUser 메서드 추가
새로 초대된 사용자인지 판단하는 로직
사용자의 입장 시간이 채팅방 생성 시간보다 늦은지 확인
이전 ENTER 메시지 이력 체크


## hasNotEnteredBefore 메서드 추가
해당 사용자의 이전 ENTER 메시지 존재 여부 확인
중복 ENTER 메시지 생성 방지



## 🔧 수정된 기능

isFirstTimeEntry 메서드 개선

기존 로직에 새로 초대된 사용자 판단 로직 추가
Objects.isNull(userJoinTime) || isNewInvitedUser(...) 조건으로 변경