### PR TITLE
모집 게시글 생성 시 필요한 태그에 대해 어노테이션 문제 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.recruitment.validation.annotation;
 
 import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.lang.annotation.ElementType;
@@ -14,4 +15,10 @@ import java.lang.annotation.Target;
 @Size(max = 100)
 @Constraint(validatedBy = {})
 public @interface BoardTag {
+
+    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 최대 100자입니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-@Pattern(regexp = "^[a-zA-Z0-9가-힣]+[a-zA-Z0-9가-힣,]*$")
+@Pattern(regexp = "^[a-zA-Z0-9가-힣]+(,[a-zA-Z0-9가-힣])*$")
 @Size(max = 100)
 @Constraint(validatedBy = {})
 public @interface BoardTag {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
 @ReportAsSingleViolation
 public @interface BoardTag {
 
-    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 콤마(,)를 포함한 최대 100자입니다";
+    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 쉼표(,)를 포함한 최대 100자입니다";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-@Pattern(regexp = "^[a-zA-Z0-9가-힣]+(,[a-zA-Z0-9가-힣])*$")
+@Pattern(regexp = "^[a-zA-Z0-9가-힣,]+$")
 @Size(max = 100)
 @Constraint(validatedBy = {})
 @ReportAsSingleViolation

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.recruitment.validation.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.lang.annotation.ElementType;
@@ -14,9 +15,10 @@ import java.lang.annotation.Target;
 @Pattern(regexp = "^[a-zA-Z0-9가-힣]+(,[a-zA-Z0-9가-힣])*$")
 @Size(max = 100)
 @Constraint(validatedBy = {})
+@ReportAsSingleViolation
 public @interface BoardTag {
 
-    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 최대 100자입니다";
+    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 콤마(,)를 포함한 최대 100자입니다";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-@Pattern(regexp = "^[a-zA-Z0-9가-힣]*$")
+@Pattern(regexp = "^[a-zA-Z0-9가-힣]+[a-zA-Z0-9가-힣,]*$")
 @Size(max = 100)
 @Constraint(validatedBy = {})
 public @interface BoardTag {


### PR DESCRIPTION
- `,`를 기준으로 나눠야 하나, `@Pattern` 어노테이션에서 `,`를 포함하지 않는 문제 개선
   - `^[a-zA-Z0-9가-힣]+[a-zA-Z0-9가-힣,]*$`
- Validator 방식을 통해 request 시 값을 검증해야 하지만 `@BoardTag`에서 Validator에 필요한 필드 값 정의가 되어있지 않은 문제 개선
   ```java

    String message() default "태그는 한글, 영문, 숫자만 포함할 수 있으며 쉼표(,)를 포함한 최대 100자입니다";

    Class<?>[] groups() default {};

    Class<? extends Payload>[] payload() default {};
   ```