### PR TITLE
채팅방 입장 REST API에 ENTER 시스템 메시지 생성 기능 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -82,10 +82,11 @@ public class ChatController {
     }
 
     @GetMapping("/room/{roomId}/enter")
-    public ResponseEntity<Void> enterRoom(@PathVariable("roomId") String roomId) {
+    public ResponseEntity<ChatMessage> enterRoom(@PathVariable("roomId") String roomId) {
         Long currentUserId = getCurrentUserId();
         chatService.enterChatRoom(roomId, currentUserId);
-        return ResponseEntity.ok().build();
+        ChatMessage enterMessage = chatService.checkFirstTimeEntryAndCreateEnterMessage(roomId, currentUserId);
+        return ResponseEntity.ok(enterMessage);
     }
 
     @PostMapping("/room/{roomId}/leave")

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -282,12 +282,10 @@ public class ChatService {
         return joinTime;
     }
 
-    private ChatMessage checkFirstTimeEntryAndCreateEnterMessage(String roomId, Long userId) {
+    public ChatMessage checkFirstTimeEntryAndCreateEnterMessage(String roomId, Long userId) {
         chatValidator.validateUserForRoom(roomId, userId);
 
-        boolean shouldCreateEnterMessage = isFirstTimeEntry(roomId, userId);
-
-        if (shouldCreateEnterMessage) {
+        if (isFirstTimeEntry(roomId, userId)) {
             return createAndSaveSystemMessage(roomId, userId, MessageType.ENTER);
         }
         return null;


### PR DESCRIPTION
기존 그룹 채팅방에 새로운 참가자가 입장할 때 ENTER 시스템 메시지가 생성되지 않던 문제를 해결하기 위해 REST API 엔드포인트에 시스템 메시지 생성 기능을 추가했습니다.

## 📋 동작 방식
### 기존
GET /chat/room/{roomId}/enter 호출
입장 검증만 수행
빈 응답 반환

### 변경 후
GET /chat/room/{roomId}/enter 호출
입장 검증 수행
첫 입장인지 확인하여 ENTER 시스템 메시지 생성
생성된 메시지를 응답으로 반환