### PR TITLE
회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -20,7 +19,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @Setter
-    @Getter
     @Builder.Default
     @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
     protected boolean isDeleted = false;

--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -19,6 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @Setter
+    @Getter
     @Builder.Default
     @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
     protected boolean isDeleted = false;

--- a/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/BaseEntity.java
@@ -21,13 +21,13 @@ public abstract class BaseEntity {
     @Setter
     @Builder.Default
     @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
-    private boolean isDeleted = false;
+    protected boolean isDeleted = false;
 
     @Column(name = "created_at", updatable = false)
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,6 +54,13 @@ public class MemberController {
     @PostMapping("/validate/nickname")
     public ResponseEntity<Void> validateNickname(@RequestBody @Valid NicknameValidateRequest request) {
         memberService.checkNicknameDuplication(request.nickname());
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember() {
+        memberService.deleteMember();
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -10,9 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,14 +46,5 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    public void onPrePersist() {
-        if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
-        }
-    }
+    
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -17,14 +17,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@SQLRestriction("is_deleted = false")
 @Table(name = "member")
 public class Member extends BaseEntity {
 
@@ -53,6 +51,7 @@ public class Member extends BaseEntity {
         this.nickname = "익명_" + id;
         this.password = "deleted";
         this.studentId = null;
+        super.isDeleted = true;
         super.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,13 +44,4 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
-
-    public void delete() {
-        this.email = "deleted_" + id; // 이메일을 삭제된 것으로 변경
-        this.nickname = "익명_" + id;
-        this.password = "deleted";
-        this.studentId = null;
-        super.isDeleted = true;
-        super.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/entity/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,5 +47,12 @@ public class Member extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
-    
+
+    public void delete() {
+        this.email = "deleted_" + id; // 이메일을 삭제된 것으로 변경
+        this.nickname = "익명_" + id;
+        this.password = "deleted";
+        this.studentId = null;
+        super.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
@@ -15,5 +15,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email AND m.isDeleted = false")
-    boolean existsByEmailAndDeletedFalse(@Param("email") String email);
+    boolean existsByEmailAndIsDeletedFalse(@Param("email") String email);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepository.java
@@ -4,13 +4,16 @@ import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
 import com.dongsoop.dongsoop.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<LoginAuthenticate> findLoginAuthenticateByEmail(String email);
 
     boolean existsByEmail(String email);
 
-    Optional<LoginAuthenticate> findLoginAuthenticateByNickname(String nickname);
-
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email AND m.isDeleted = false")
+    boolean existsByEmailAndDeletedFalse(@Param("email") String email);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
@@ -7,5 +7,5 @@ public interface MemberRepositoryCustom {
 
     Optional<LoginMemberDetails> findLoginMemberDetailById(Long id);
 
-    void softDelete(Long id, String emailAlias, String passwordAlias);
+    long softDelete(Long id, String emailAlias, String passwordAlias);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
@@ -7,5 +7,5 @@ public interface MemberRepositoryCustom {
 
     Optional<LoginMemberDetails> findLoginMemberDetailById(Long id);
 
-    void softDelete(Long id);
+    void softDelete(Long id, String emailAlias, String passwordAlias);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 public interface MemberRepositoryCustom {
 
     Optional<LoginMemberDetails> findLoginMemberDetailById(Long id);
+
+    void softDelete(Long id);
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -8,7 +8,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,7 +17,6 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     private static final QMember member = QMember.member;
 
     private final JPAQueryFactory queryFactory;
-    private final PasswordEncoder passwordEncoder;
 
     public Optional<LoginMemberDetails> findLoginMemberDetailById(Long id) {
         LoginMemberDetails loginMemberDetails = queryFactory.select(Projections.constructor(LoginMemberDetails.class,
@@ -32,7 +30,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
         return Optional.ofNullable(loginMemberDetails);
     }
-    
+
     public void softDelete(Long id, String emailAlias, String passwordAlias) {
         queryFactory.update(member)
                 .set(member.email, emailAlias)

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -19,7 +19,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    @Value("${member.nickname.alias.prefix}")
+    @Value("${member.nickname.alias.prefix:익명_}")
     private String nicknameAliasPrefix;
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,6 +18,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     private static final QMember member = QMember.member;
 
     private final JPAQueryFactory queryFactory;
+    private final PasswordEncoder passwordEncoder;
 
     public Optional<LoginMemberDetails> findLoginMemberDetailById(Long id) {
         LoginMemberDetails loginMemberDetails = queryFactory.select(Projections.constructor(LoginMemberDetails.class,
@@ -30,13 +32,12 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
         return Optional.ofNullable(loginMemberDetails);
     }
-
-
-    public void softDelete(Long id) {
+    
+    public void softDelete(Long id, String emailAlias, String passwordAlias) {
         queryFactory.update(member)
-                .set(member.email, "deleted_" + id)
+                .set(member.email, emailAlias)
                 .set(member.nickname, "익명_" + id)
-                .set(member.password, "deleted")
+                .set(member.password, passwordAlias)
                 .setNull(member.studentId)
                 .set(member.isDeleted, true)
                 .set(member.updatedAt, LocalDateTime.now())

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.dongsoop.dongsoop.member.entity.QMember;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -28,6 +29,20 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .fetchOne();
 
         return Optional.ofNullable(loginMemberDetails);
+    }
+
+
+    public void softDelete(Long id) {
+        queryFactory.update(member)
+                .set(member.email, "deleted_" + id)
+                .set(member.nickname, "익명_" + id)
+                .set(member.password, "deleted")
+                .set(member.studentId, (String) null)
+                .set(member.isDeleted, true)
+                .set(member.updatedAt, LocalDateTime.now())
+                .where(member.isDeleted.eq(false)
+                        .and(member.id.eq(id)))
+                .execute();
     }
 
     private BooleanExpression eqId(Long id) {

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -31,8 +31,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
         return Optional.ofNullable(loginMemberDetails);
     }
 
-    public void softDelete(Long id, String emailAlias, String passwordAlias) {
-        queryFactory.update(member)
+    public long softDelete(Long id, String emailAlias, String passwordAlias) {
+        return queryFactory.update(member)
                 .set(member.email, emailAlias)
                 .set(member.nickname, "익명_" + id)
                 .set(member.password, passwordAlias)

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -18,6 +18,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    @Override
     public Optional<LoginMemberDetails> findLoginMemberDetailById(Long id) {
         LoginMemberDetails loginMemberDetails = queryFactory.select(Projections.constructor(LoginMemberDetails.class,
                         member.id.as("id"),
@@ -31,6 +32,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
         return Optional.ofNullable(loginMemberDetails);
     }
 
+    @Override
     public long softDelete(Long id, String emailAlias, String passwordAlias) {
         return queryFactory.update(member)
                 .set(member.email, emailAlias)

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,6 +18,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     private static final QMember member = QMember.member;
 
     private final JPAQueryFactory queryFactory;
+
+    @Value("${member.nickname.alias.prefix}")
+    private String nicknameAliasPrefix;
 
     @Override
     public Optional<LoginMemberDetails> findLoginMemberDetailById(Long id) {
@@ -36,7 +40,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     public long softDelete(Long id, String emailAlias, String passwordAlias) {
         return queryFactory.update(member)
                 .set(member.email, emailAlias)
-                .set(member.nickname, "익명_" + id)
+                .set(member.nickname, this.nicknameAliasPrefix + id)
                 .set(member.password, passwordAlias)
                 .setNull(member.studentId)
                 .set(member.isDeleted, true)

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -37,7 +37,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .set(member.email, "deleted_" + id)
                 .set(member.nickname, "익명_" + id)
                 .set(member.password, "deleted")
-                .set(member.studentId, (String) null)
+                .setNull(member.studentId)
                 .set(member.isDeleted, true)
                 .set(member.updatedAt, LocalDateTime.now())
                 .where(member.isDeleted.eq(false)

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberService.java
@@ -23,4 +23,6 @@ public interface MemberService {
     void checkEmailDuplication(String email);
 
     void checkNicknameDuplication(String nickname);
+
+    void deleteMember();
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -188,6 +188,7 @@ public class MemberServiceImpl implements MemberService {
         throw new NotAuthenticationException();
     }
 
+    @Transactional
     public void deleteMember() {
         // 요청 사용자 id
         Long requesterId = getMemberIdByAuthentication();
@@ -195,8 +196,11 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(requesterId)
                 .orElseThrow(MemberNotFoundException::new);
 
+        if (member.isDeleted()) {
+            throw new MemberNotFoundException();
+        }
+
         // 가명 처리
         member.delete();
-        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -83,7 +83,9 @@ public class MemberServiceImpl implements MemberService {
                 .build();
     }
 
+    @Transactional
     public LoginDetails login(LoginRequest loginRequest) {
+        validateMemberExists(loginRequest.getEmail());
         LoginAuthenticate loginAuthenticate = getLoginAuthenticate(loginRequest.getEmail());
 
         String password = loginAuthenticate.getPassword();
@@ -100,6 +102,13 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(MemberNotFoundException::new);
 
         return new LoginDetails(loginMemberDetails, issuedToken);
+    }
+
+    private void validateMemberExists(String email) {
+        boolean isMemberExists = memberRepository.existsByEmailAndDeletedFalse(email);
+        if (!isMemberExists) {
+            throw new MemberNotFoundException();
+        }
     }
 
     private Authentication getAuthenticationByLoginAuthenticate(LoginAuthenticate loginAuthenticate) {

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -55,6 +55,7 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberDuplicationValidator memberDuplicationValidator;
 
+    @Override
     @Transactional
     public void signup(SignupRequest request) {
         memberDuplicationValidator.validateEmailDuplication(request.getEmail());
@@ -83,6 +84,7 @@ public class MemberServiceImpl implements MemberService {
                 .build();
     }
 
+    @Override
     @Transactional(readOnly = true)
     public LoginDetails login(LoginRequest loginRequest) {
         validateMemberExists(loginRequest.getEmail());
@@ -131,6 +133,7 @@ public class MemberServiceImpl implements MemberService {
         return optionalAuthenticate.orElseThrow(MemberNotFoundException::new);
     }
 
+    @Override
     public Member getMemberReferenceByContext() {
         Long id = getMemberIdByContext();
         return memberRepository.getReferenceById(id);
@@ -153,12 +156,14 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
+    @Override
     public String getNicknameById(Long userId) {
         return memberRepository.findById(userId)
                 .map(Member::getNickname)
                 .orElseThrow(MemberNotFoundException::new);
     }
 
+    @Override
     public Long getMemberIdByAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext()
                 .getAuthentication();
@@ -175,6 +180,7 @@ public class MemberServiceImpl implements MemberService {
         throw new NotAuthenticationException();
     }
 
+    @Override
     @Transactional
     public void deleteMember() {
         // 요청 사용자 id

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -37,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
@@ -192,6 +194,7 @@ public class MemberServiceImpl implements MemberService {
         String passwordAlias = passwordEncoder.encode(UUID.randomUUID().toString());
         long updatedCount = memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
         if (updatedCount == 0L) {
+            log.error("Member with id {} not found or already deleted", requesterId);
             throw new MemberNotFoundException();
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -108,7 +108,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private void validateMemberExists(String email) {
-        boolean isMemberExists = memberRepository.existsByEmailAndDeletedFalse(email);
+        boolean isMemberExists = memberRepository.existsByEmailAndIsDeletedFalse(email);
         if (!isMemberExists) {
             throw new MemberNotFoundException();
         }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -171,14 +171,7 @@ public class MemberServiceImpl implements MemberService {
         // 요청 사용자 id
         Long requesterId = getMemberIdByAuthentication();
 
-        Member member = memberRepository.findById(requesterId)
-                .orElseThrow(MemberNotFoundException::new);
-
-        if (member.isDeleted()) {
-            throw new MemberNotFoundException();
-        }
-
-        // 가명 처리
-        member.delete();
+        // 가명처리
+        memberRepositoryCustom.softDelete(requesterId);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -83,7 +83,7 @@ public class MemberServiceImpl implements MemberService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public LoginDetails login(LoginRequest loginRequest) {
         validateMemberExists(loginRequest.getEmail());
         LoginAuthenticate loginAuthenticate = getLoginAuthenticate(loginRequest.getEmail());

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -190,6 +190,9 @@ public class MemberServiceImpl implements MemberService {
         // 가명처리
         String emailAlias = passwordEncoder.encode(UUID.randomUUID().toString());
         String passwordAlias = passwordEncoder.encode(UUID.randomUUID().toString());
-        memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
+        long updatedCount = memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
+        if (updatedCount == 0L) {
+            throw new MemberNotFoundException();
+        }
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -187,4 +187,16 @@ public class MemberServiceImpl implements MemberService {
 
         throw new NotAuthenticationException();
     }
+
+    public void deleteMember() {
+        // 요청 사용자 id
+        Long requesterId = getMemberIdByAuthentication();
+
+        Member member = memberRepository.findById(requesterId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        // 가명 처리
+        member.delete();
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -25,6 +25,7 @@ import com.dongsoop.dongsoop.role.repository.RoleRepository;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -187,6 +188,8 @@ public class MemberServiceImpl implements MemberService {
         Long requesterId = getMemberIdByAuthentication();
 
         // 가명처리
-        memberRepositoryCustom.softDelete(requesterId);
+        String emailAlias = passwordEncoder.encode(UUID.randomUUID().toString());
+        String passwordAlias = passwordEncoder.encode(UUID.randomUUID().toString());
+        memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
     }
 }


### PR DESCRIPTION
회원 탈퇴는 가명 처리를 통해 기존 게시글 데이터는 삭제되지 않도록 처리했습니다.

- BaseEntity 클래스의 필드를 protected로 설정하여 상속받는 클래스에서 접근이 가능하도록 수정되었습니다.
- 회원 탈퇴용 API를 추가하였습니다.
- 가명 처리 방식의 회원 탈퇴 로직 추가에 따라 로그인 시 탈퇴여부를 검증하는 로직이 추가되었습니다.
- 탈퇴된 회원이 작성한 글에 대해 가명으로 노출하기 위해 `@SQLRestriction("is_deleted = false")`를 제거하였습니다.