### PR TITLE
장터 게시판 판매/구매 타입 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/marketplace/controller/MarketplaceBoardController.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/controller/MarketplaceBoardController.java
@@ -5,6 +5,7 @@ import com.dongsoop.dongsoop.marketplace.dto.CreateMarketplaceBoardRequest;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardDetails;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardOverview;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceBoard;
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import com.dongsoop.dongsoop.marketplace.service.MarketplaceBoardService;
 import com.dongsoop.dongsoop.role.entity.RoleType;
 import jakarta.validation.Valid;
@@ -33,10 +34,11 @@ public class MarketplaceBoardController {
 
     private final MarketplaceBoardService marketplaceBoardService;
 
-    @GetMapping
-    public ResponseEntity<List<MarketplaceBoardOverview>> getMarketplaceBoards(Pageable pageable) {
+    @GetMapping("/type/{type}")
+    public ResponseEntity<List<MarketplaceBoardOverview>> getMarketplaceBoards(Pageable pageable,
+                                                                               @PathVariable MarketplaceType type) {
         List<MarketplaceBoardOverview> marketplaceBoardOverviewList = marketplaceBoardService.getMarketplaceBoards(
-                pageable);
+                pageable, type);
 
         return ResponseEntity.ok(marketplaceBoardOverviewList);
     }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/dto/CreateMarketplaceBoardRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/dto/CreateMarketplaceBoardRequest.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.marketplace.dto;
 
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -14,6 +15,9 @@ public record CreateMarketplaceBoardRequest(
 
         @NotNull
         @Positive
-        Long price
+        Long price,
+
+        @NotNull
+        MarketplaceType type
 ) {
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/dto/MarketplaceBoardDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/dto/MarketplaceBoardDetails.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.marketplace.dto;
 
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,17 +14,20 @@ public record MarketplaceBoardDetails(
         String content,
         Long price,
         LocalDateTime createdAt,
+        MarketplaceType type,
         Long contactCount,
         Set<String> imageUrlList,
         MarketplaceViewType viewType
 ) {
     public MarketplaceBoardDetails(Long id, String title, String content, Long price, LocalDateTime createdAt,
-                                   Long contactCount, String imageUrls, MarketplaceViewType viewType) {
+                                   MarketplaceType type, Long contactCount, String imageUrls,
+                                   MarketplaceViewType viewType) {
         this(id,
                 title,
                 content,
                 price,
                 createdAt,
+                type,
                 contactCount,
                 splitImageUrl(imageUrls),
                 viewType);

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/dto/MarketplaceBoardOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/dto/MarketplaceBoardOverview.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.marketplace.dto;
 
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import java.time.LocalDateTime;
 
 public record MarketplaceBoardOverview(
@@ -10,6 +11,7 @@ public record MarketplaceBoardOverview(
         Long price,
         LocalDateTime createdAt,
         Long contactCount,
-        String imageUrl
+        String imageUrl,
+        MarketplaceType type
 ) {
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/entity/MarketplaceBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/entity/MarketplaceBoard.java
@@ -3,6 +3,8 @@ package com.dongsoop.dongsoop.marketplace.entity;
 import com.dongsoop.dongsoop.board.Board;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,4 +34,8 @@ public class MarketplaceBoard extends Board {
     @Builder.Default
     @Column(name = "status", nullable = false)
     private MarketplaceBoardStatus status = MarketplaceBoardStatus.SELLING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private MarketplaceType type;
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/entity/MarketplaceType.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/entity/MarketplaceType.java
@@ -1,0 +1,6 @@
+package com.dongsoop.dongsoop.marketplace.entity;
+
+public enum MarketplaceType {
+    SELL,
+    BUY
+}

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/repository/MarketplaceBoardRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/repository/MarketplaceBoardRepositoryCustom.java
@@ -3,13 +3,14 @@ package com.dongsoop.dongsoop.marketplace.repository;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardDetails;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardOverview;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceViewType;
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 
 public interface MarketplaceBoardRepositoryCustom {
 
-    List<MarketplaceBoardOverview> findMarketplaceBoardOverviewByPage(Pageable pageable);
+    List<MarketplaceBoardOverview> findMarketplaceBoardOverviewByPage(Pageable pageable, MarketplaceType type);
 
     Optional<MarketplaceBoardDetails> findMarketplaceBoardDetails(Long id, MarketplaceViewType viewType);
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardService.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardService.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.marketplace.dto.CreateMarketplaceBoardRequest;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardDetails;
 import com.dongsoop.dongsoop.marketplace.dto.MarketplaceBoardOverview;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceBoard;
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +14,7 @@ public interface MarketplaceBoardService {
 
     MarketplaceBoard create(CreateMarketplaceBoardRequest request, MultipartFile[] images) throws IOException;
 
-    List<MarketplaceBoardOverview> getMarketplaceBoards(Pageable pageable);
+    List<MarketplaceBoardOverview> getMarketplaceBoards(Pageable pageable, MarketplaceType type);
 
     MarketplaceBoardDetails getBoardDetails(Long boardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardServiceImpl.java
@@ -9,6 +9,7 @@ import com.dongsoop.dongsoop.marketplace.dto.MarketplaceViewType;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceBoard;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceImage;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceImage.MarketplaceImageId;
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceType;
 import com.dongsoop.dongsoop.marketplace.repository.MarketplaceBoardRepository;
 import com.dongsoop.dongsoop.marketplace.repository.MarketplaceBoardRepositoryCustom;
 import com.dongsoop.dongsoop.marketplace.repository.MarketplaceImageRepository;
@@ -54,7 +55,7 @@ public class MarketplaceBoardServiceImpl implements MarketplaceBoardService {
         return savedBoard;
     }
 
-    private void saveImages(MultipartFile[] images, MarketplaceBoard board) throws IOException {
+    private void saveImages(MultipartFile[] images, MarketplaceBoard board) {
         List<MarketplaceImage> imageLinkList = Arrays.stream(images)
                 .map(image -> uploadImage(image, board))
                 .toList();
@@ -72,8 +73,8 @@ public class MarketplaceBoardServiceImpl implements MarketplaceBoardService {
         }
     }
 
-    public List<MarketplaceBoardOverview> getMarketplaceBoards(Pageable pageable) {
-        return marketplaceBoardRepositoryCustom.findMarketplaceBoardOverviewByPage(pageable);
+    public List<MarketplaceBoardOverview> getMarketplaceBoards(Pageable pageable, MarketplaceType type) {
+        return marketplaceBoardRepositoryCustom.findMarketplaceBoardOverviewByPage(pageable, type);
     }
 
     public MarketplaceBoardDetails getBoardDetails(Long boardId) {


### PR DESCRIPTION
장터 게시판에 판매 및 구매 타입이 추가됩니다.

- 장터 게시판 목록 조회 시 타입(BUY, SELL)을 필요로 하게 됩니다
- 장터 게시판 목록 및 상세 페이지 조회 시 타입(BUY, SELL)이 포함됩니다.