### PR TITLE
장터 게시판 생성 시 타입 누락 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardMapper.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceBoardMapper.java
@@ -21,6 +21,7 @@ public class MarketplaceBoardMapper {
                 .content(request.content())
                 .price(request.price())
                 .author(author)
+                .type(request.type())
                 .build();
     }
 }


### PR DESCRIPTION
장터 게시판 생성 시 request 객체를 entity 객체로 변환하는 과정에서 type 필드가 누락되어  
not null 제약 위반으로 장터 게시글이 생성되지 않는 문제

- MarketplaceBoardMapper.class에 toEntity에서 type을 입력받도록 수정