### PR TITLE
사용자 제재 여부기능 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/report/controller/ReportController.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.report.controller;
 
 import com.dongsoop.dongsoop.report.dto.CreateReportRequest;
 import com.dongsoop.dongsoop.report.dto.ProcessSanctionRequest;
+import com.dongsoop.dongsoop.report.dto.SanctionStatusResponse;
 import com.dongsoop.dongsoop.report.entity.ReportFilterType;
 import com.dongsoop.dongsoop.report.service.ReportService;
 import com.dongsoop.dongsoop.role.entity.RoleType;
@@ -27,6 +28,12 @@ public class ReportController {
     public ResponseEntity<Void> createReport(@RequestBody @Valid CreateReportRequest request) {
         reportService.createReport(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/sanction-status")
+    public ResponseEntity<SanctionStatusResponse> checkSanctionStatus() {
+        SanctionStatusResponse response = reportService.checkAndUpdateSanctionStatus();
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/sanctions")

--- a/src/main/java/com/dongsoop/dongsoop/report/dto/SanctionStatusResponse.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/dto/SanctionStatusResponse.java
@@ -1,0 +1,13 @@
+package com.dongsoop.dongsoop.report.dto;
+
+import java.time.LocalDateTime;
+
+public record SanctionStatusResponse(
+        boolean isSanctioned,
+        String sanctionType,
+        String reason,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String description
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/report/entity/Sanction.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/entity/Sanction.java
@@ -1,0 +1,52 @@
+package com.dongsoop.dongsoop.report.entity;
+
+import com.dongsoop.dongsoop.common.BaseEntity;
+import com.dongsoop.dongsoop.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "sanction")
+public class Sanction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "sanction_type", length = 50, nullable = false)
+    private String sanctionType;
+
+    @Column(name = "reason", length = 500, nullable = false)
+    private String reason;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return now.isAfter(endDate);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/report/repository/SanctionRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/repository/SanctionRepository.java
@@ -1,0 +1,14 @@
+package com.dongsoop.dongsoop.report.repository;
+
+import com.dongsoop.dongsoop.report.entity.Sanction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SanctionRepository extends JpaRepository<Sanction, Long> {
+
+    @Query("SELECT s FROM Sanction s WHERE s.member.id = :memberId AND s.isActive = true")
+    Optional<Sanction> findActiveSanctionByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/dongsoop/dongsoop/report/service/ReportService.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/service/ReportService.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.report.service;
 
 import com.dongsoop.dongsoop.report.dto.CreateReportRequest;
 import com.dongsoop.dongsoop.report.dto.ProcessSanctionRequest;
+import com.dongsoop.dongsoop.report.dto.SanctionStatusResponse;
 import com.dongsoop.dongsoop.report.entity.ReportFilterType;
 import org.springframework.data.domain.Pageable;
 
@@ -14,4 +15,6 @@ public interface ReportService {
     void processSanction(ProcessSanctionRequest request);
 
     List<?> getReports(ReportFilterType filterType, Pageable pageable);
+
+    SanctionStatusResponse checkAndUpdateSanctionStatus();
 }

--- a/src/test/java/com/dongsoop/dongsoop/report/ReportControllerTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/report/ReportControllerTest.java
@@ -1,0 +1,82 @@
+package com.dongsoop.dongsoop.report;
+
+import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
+import com.dongsoop.dongsoop.report.controller.ReportController;
+import com.dongsoop.dongsoop.report.dto.SanctionStatusResponse;
+import com.dongsoop.dongsoop.report.service.ReportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ReportController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private JwtFilter jwtFilter;
+
+    @Test
+    @DisplayName("제재당하지 않은 사용자의 제재 상태 확인 시 정상 응답을 반환한다")
+    void checkSanctionStatus_WhenNotSanctioned_ShouldReturnNormalStatus() throws Exception {
+        // given
+        SanctionStatusResponse response = new SanctionStatusResponse(
+                false, null, null, null, null, null
+        );
+        when(reportService.checkAndUpdateSanctionStatus()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/reports/sanction-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSanctioned").value(false))
+                .andExpect(jsonPath("$.sanctionType").isEmpty())
+                .andExpect(jsonPath("$.reason").isEmpty())
+                .andExpect(jsonPath("$.startDate").isEmpty())
+                .andExpect(jsonPath("$.endDate").isEmpty())
+                .andExpect(jsonPath("$.description").isEmpty());
+    }
+
+    @Test
+    @DisplayName("제재당한 사용자의 제재 상태 확인 시 제재 정보를 반환한다")
+    void checkSanctionStatus_WhenSanctioned_ShouldReturnSanctionInfo() throws Exception {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 31, 23, 59);
+
+        SanctionStatusResponse response = new SanctionStatusResponse(
+                true,
+                "TEMPORARY_BAN",
+                "부적절한 게시글 작성",
+                startDate,
+                endDate,
+                "30일 임시 정지 처분"
+        );
+        when(reportService.checkAndUpdateSanctionStatus()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/reports/sanction-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSanctioned").value(true))
+                .andExpect(jsonPath("$.sanctionType").value("TEMPORARY_BAN"))
+                .andExpect(jsonPath("$.reason").value("부적절한 게시글 작성"))
+                .andExpect(jsonPath("$.startDate").value("2025-01-01T00:00:00"))
+                .andExpect(jsonPath("$.endDate").value("2025-01-31T23:59:00"))
+                .andExpect(jsonPath("$.description").value("30일 임시 정지 처분"));
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/report/ReportFilterTypeTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/report/ReportFilterTypeTest.java
@@ -1,0 +1,42 @@
+package com.dongsoop.dongsoop.report;
+
+import com.dongsoop.dongsoop.report.entity.ReportFilterType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReportFilterTypeTest {
+
+    @Test
+    @DisplayName("ReportFilterType enum이 올바른 값들을 포함한다")
+    void reportFilterType_ShouldContainExpectedValues() {
+        // when & then
+        assertThat(ReportFilterType.values()).containsExactly(
+                ReportFilterType.ALL,
+                ReportFilterType.UNPROCESSED,
+                ReportFilterType.PROCESSED,
+                ReportFilterType.ACTIVE_SANCTIONS
+        );
+    }
+
+    @Test
+    @DisplayName("ReportFilterType의 이름이 올바르다")
+    void reportFilterType_ShouldHaveCorrectNames() {
+        // when & then
+        assertThat(ReportFilterType.ALL.name()).isEqualTo("ALL");
+        assertThat(ReportFilterType.UNPROCESSED.name()).isEqualTo("UNPROCESSED");
+        assertThat(ReportFilterType.PROCESSED.name()).isEqualTo("PROCESSED");
+        assertThat(ReportFilterType.ACTIVE_SANCTIONS.name()).isEqualTo("ACTIVE_SANCTIONS");
+    }
+
+    @Test
+    @DisplayName("문자열로부터 ReportFilterType을 올바르게 변환한다")
+    void reportFilterType_ShouldConvertFromString() {
+        // when & then
+        assertThat(ReportFilterType.valueOf("ALL")).isEqualTo(ReportFilterType.ALL);
+        assertThat(ReportFilterType.valueOf("UNPROCESSED")).isEqualTo(ReportFilterType.UNPROCESSED);
+        assertThat(ReportFilterType.valueOf("PROCESSED")).isEqualTo(ReportFilterType.PROCESSED);
+        assertThat(ReportFilterType.valueOf("ACTIVE_SANCTIONS")).isEqualTo(ReportFilterType.ACTIVE_SANCTIONS);
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/report/ReportServiceTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/report/ReportServiceTest.java
@@ -1,0 +1,127 @@
+package com.dongsoop.dongsoop.report;
+
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.repository.MemberRepository;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.report.dto.SanctionStatusResponse;
+import com.dongsoop.dongsoop.report.entity.Sanction;
+import com.dongsoop.dongsoop.report.repository.SanctionRepository;
+import com.dongsoop.dongsoop.report.service.ReportServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    private ReportServiceImpl reportService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SanctionRepository sanctionRepository;
+
+    @Test
+    @DisplayName("제재 이력이 없는 사용자는 정상 상태를 반환한다")
+    void checkAndUpdateSanctionStatus_WhenNoSanction_ShouldReturnNormalStatus() {
+        // given
+        Long memberId = 1L;
+        when(memberService.getMemberIdByAuthentication()).thenReturn(memberId);
+        when(sanctionRepository.findActiveSanctionByMemberId(memberId)).thenReturn(Optional.empty());
+
+        // when
+        SanctionStatusResponse response = reportService.checkAndUpdateSanctionStatus();
+
+        // then
+        assertThat(response.isSanctioned()).isFalse();
+        assertThat(response.sanctionType()).isNull();
+        assertThat(response.reason()).isNull();
+        assertThat(response.startDate()).isNull();
+        assertThat(response.endDate()).isNull();
+        assertThat(response.description()).isNull();
+
+        verify(sanctionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("활성 제재가 있는 사용자는 제재 정보를 반환한다")
+    void checkAndUpdateSanctionStatus_WhenActiveSanction_ShouldReturnSanctionInfo() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().id(memberId).build();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime endDate = now.plusDays(10);
+
+        Sanction sanction = Sanction.builder()
+                .member(member)
+                .sanctionType("TEMPORARY_BAN")
+                .reason("부적절한 게시글")
+                .startDate(now.minusDays(1))
+                .endDate(endDate)
+                .description("임시 정지")
+                .isActive(true)
+                .build();
+
+        when(memberService.getMemberIdByAuthentication()).thenReturn(memberId);
+        when(sanctionRepository.findActiveSanctionByMemberId(memberId)).thenReturn(Optional.of(sanction));
+
+        // when
+        SanctionStatusResponse response = reportService.checkAndUpdateSanctionStatus();
+
+        // then
+        assertThat(response.isSanctioned()).isTrue();
+        assertThat(response.sanctionType()).isEqualTo("TEMPORARY_BAN");
+        assertThat(response.reason()).isEqualTo("부적절한 게시글");
+        assertThat(response.description()).isEqualTo("임시 정지");
+
+        verify(sanctionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("만료된 제재는 자동으로 비활성화되고 정상 상태를 반환한다")
+    void checkAndUpdateSanctionStatus_WhenExpiredSanction_ShouldDeactivateAndReturnNormal() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().id(memberId).build();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiredEndDate = now.minusDays(1);
+
+        Sanction expiredSanction = Sanction.builder()
+                .member(member)
+                .sanctionType("TEMPORARY_BAN")
+                .reason("부적절한 게시글")
+                .startDate(now.minusDays(10))
+                .endDate(expiredEndDate)
+                .description("임시 정지")
+                .isActive(true)
+                .build();
+
+        when(memberService.getMemberIdByAuthentication()).thenReturn(memberId);
+        when(sanctionRepository.findActiveSanctionByMemberId(memberId)).thenReturn(Optional.of(expiredSanction));
+
+        // when
+        SanctionStatusResponse response = reportService.checkAndUpdateSanctionStatus();
+
+        // then
+        assertThat(response.isSanctioned()).isFalse();
+        assertThat(response.sanctionType()).isNull();
+
+        verify(sanctionRepository).save(expiredSanction);
+        assertThat(expiredSanction.getIsActive()).isFalse();
+    }
+}

--- a/src/test/java/com/dongsoop/dongsoop/report/SanctionTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/report/SanctionTest.java
@@ -1,0 +1,63 @@
+package com.dongsoop.dongsoop.report;
+
+import com.dongsoop.dongsoop.report.entity.Sanction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SanctionTest {
+
+    @Test
+    @DisplayName("제재 종료일이 현재 시간보다 이전이면 만료된 것으로 판단한다")
+    void isExpired_WhenEndDateIsPast_ShouldReturnTrue() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime pastEndDate = now.minusDays(1);
+
+        Sanction sanction = Sanction.builder()
+                .endDate(pastEndDate)
+                .build();
+
+        // when
+        boolean expired = sanction.isExpired(now);
+
+        // then
+        assertThat(expired).isTrue();
+    }
+
+    @Test
+    @DisplayName("제재 종료일이 현재 시간보다 이후이면 만료되지 않은 것으로 판단한다")
+    void isExpired_WhenEndDateIsFuture_ShouldReturnFalse() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime futureEndDate = now.plusDays(1);
+
+        Sanction sanction = Sanction.builder()
+                .endDate(futureEndDate)
+                .build();
+
+        // when
+        boolean expired = sanction.isExpired(now);
+
+        // then
+        assertThat(expired).isFalse();
+    }
+
+    @Test
+    @DisplayName("제재를 비활성화하면 isActive가 false로 변경된다")
+    void deactivate_ShouldSetIsActiveToFalse() {
+        // given
+        Sanction sanction = Sanction.builder()
+                .isActive(true)
+                .build();
+
+        // when
+        sanction.deactivate();
+
+        // then
+        assertThat(sanction.getIsActive()).isFalse();
+    }
+}


### PR DESCRIPTION
## 📋 변경 사항

### ✨ 새로운 기능
- **제재 상태 확인 API 추가**: 자동로그인 시 사용자 제재 여부를 확인할 수 있는 엔드포인트 구현
- **제재 자동 해제 로직**: 제재 기간이 만료된 사용자의 제재를 자동으로 해제하는 기능 추가

### 🏗️ 구조 변경
- **Sanction 엔티티 추가**: Member와 별도로 제재 정보를 관리하는 엔티티 구현
- **SanctionRepository 추가**: 활성 제재 조회를 위한 데이터 접근 계층 구현

### 🔧 API 엔드포인트
- `GET /reports/sanction-status`: 현재 사용자의 제재 상태 확인 및 만료된 제재 자동 해제

### 📱 클라이언트 연동
- 앱 시작 시 해당 API를 호출하여 제재 상태 확인 가능
- 제재 중인 사용자는 앱 사용 제한, 제재 해제된 사용자는 정상 이용 가능

### 🧪 테스트
- 컨트롤러, 서비스, 엔티티 계층별 단위 테스트 추가
- 정상 사용자, 제재 중인 사용자, 만료된 제재 시나리오 테스트 커버리지 확보