### PR TITLE
JWT 사용 시 두 타입으로 분리됩니다.

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/jwt/JWTType.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JWTType.java
@@ -1,0 +1,6 @@
+package com.dongsoop.dongsoop.jwt;
+
+public enum JWTType {
+
+    ACCESS, REFRESH
+}

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
@@ -20,8 +20,12 @@ import org.springframework.stereotype.Component;
 public class JwtUtil {
 
     private final JwtKeyManager jwtKeyManager;
+
     @Value("${jwt.claims.role.name}")
     private String roleClaimName;
+
+    @Value("${jwt.claims.type.name")
+    private String typeClaimName;
 
     protected Claims getClaims(String token) {
         SecretKey key = jwtKeyManager.getSecretKey();
@@ -33,12 +37,13 @@ public class JwtUtil {
                 .getPayload();
     }
 
-    protected String issue(Date tokenExpiredTime, String id, List<String> roleList) {
+    protected String issue(Date tokenExpiredTime, String id, List<String> roleList, JWTType type) {
         SecretKey key = jwtKeyManager.getSecretKey();
 
         return Jwts.builder()
                 .subject(id)
                 .claim(roleClaimName, roleList)
+                .claim(typeClaimName, type)
                 .signWith(key)
                 .expiration(tokenExpiredTime)
                 .compact();

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtValidator.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.jwt;
 
+import com.dongsoop.dongsoop.jwt.exception.NotAccessTokenException;
 import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
 import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
 import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
@@ -21,6 +22,9 @@ public class JwtValidator {
     @Value("${jwt.claims.role.name}")
     private String roleClaimName;
 
+    @Value("${jwt.claims.type.name}")
+    private String typeClaimName;
+
     public void validate(String token) {
         if (!StringUtils.hasText(token)) {
             throw new TokenMalformedException();
@@ -30,12 +34,23 @@ public class JwtValidator {
             Claims claims = jwtUtil.getClaims(token);
             Long.valueOf(claims.getSubject());
             claims.get(roleClaimName, List.class);
+            claims.get(typeClaimName, String.class);
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException(e);
         } catch (MalformedJwtException e) {
             throw new TokenMalformedException(e);
         } catch (Exception e) {
             throw new TokenUnsupportedException(e);
+        }
+    }
+
+    public void validateAccessToken(String token) {
+        validate(token);
+        Claims claims = jwtUtil.getClaims(token);
+        String type = claims.get(typeClaimName, String.class);
+
+        if (!type.equals(JWTType.ACCESS.name())) {
+            throw new NotAccessTokenException(token);
         }
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtValidator.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.jwt;
 
 import com.dongsoop.dongsoop.jwt.exception.NotAccessTokenException;
+import com.dongsoop.dongsoop.jwt.exception.NotRefreshTokenException;
 import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
 import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
 import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
@@ -51,6 +52,16 @@ public class JwtValidator {
 
         if (!type.equals(JWTType.ACCESS.name())) {
             throw new NotAccessTokenException(token);
+        }
+    }
+
+    public void validateRefreshToken(String token) {
+        validate(token);
+        Claims claims = jwtUtil.getClaims(token);
+        String type = claims.get(typeClaimName, String.class);
+
+        if (!type.equals(JWTType.REFRESH.name())) {
+            throw new NotRefreshTokenException(token);
         }
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/TokenGenerator.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/TokenGenerator.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TokenGenerator {
 
+    private final JwtUtil jwtUtil;
+    
     @Value("${jwt.expired-time.access-token}")
     private Long accessTokenExpiredTime;
 
     @Value("${jwt.expired-time.refresh-token}")
     private Long refreshTokenExpiredTime;
-
-    private final JwtUtil jwtUtil;
 
     public String generateAccessToken(Authentication authentication) {
         long now = (new Date()).getTime();
@@ -31,7 +31,7 @@ public class TokenGenerator {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
-        return jwtUtil.issue(expireAt, id, roleList);
+        return jwtUtil.issue(expireAt, id, roleList, JWTType.ACCESS);
     }
 
     public String generateRefreshToken(Authentication authentication) {
@@ -44,7 +44,7 @@ public class TokenGenerator {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
-        return jwtUtil.issue(expireAt, id, roleList);
+        return jwtUtil.issue(expireAt, id, roleList, JWTType.REFRESH);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotAccessTokenException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotAccessTokenException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.jwt.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NotAccessTokenException extends CustomException {
+
+    public NotAccessTokenException(String token) {
+        super("액세스 토큰이 아닙니다: " + token, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotRefreshTokenException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotRefreshTokenException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.jwt.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NotRefreshTokenException extends CustomException {
+
+    public NotRefreshTokenException(String token) {
+        super("리프레시 토큰이 아닙니다: " + token, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -56,7 +56,8 @@ public class JwtFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) {
         try {
             String token = extractTokenFromHeader(request);
-            validateAndSetAuthentication(token);
+            jwtValidator.validateAccessToken(token);
+            setAuthentication(token);
         } catch (TokenMalformedException | TokenNotFoundException | TokenExpiredException |
                  TokenSignatureException | TokenRoleNotAvailableException | TokenUnsupportedException exception) {
             log.error("JWT Filter processing failed with JWT exception: {}", exception.getMessage(), exception);
@@ -94,8 +95,7 @@ public class JwtFilter extends OncePerRequestFilter {
         return tokenHeader.substring(TOKEN_START_INDEX);
     }
 
-    private void validateAndSetAuthentication(String token) {
-        jwtValidator.validate(token);
+    private void setAuthentication(String token) {
         Authentication auth = jwtUtil.getAuthenticationByToken(token);
 
         SecurityContext context = SecurityContextHolder.getContext();

--- a/src/main/java/com/dongsoop/dongsoop/jwt/service/JwtServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/service/JwtServiceImpl.java
@@ -19,7 +19,7 @@ public class JwtServiceImpl implements JwtService {
     private final JwtUtil jwtUtil;
 
     public IssuedToken issuedTokenByRefreshToken(String refreshToken) {
-        jwtValidator.validate(refreshToken);
+        jwtValidator.validateRefreshToken(refreshToken);
 
         Authentication authentication = jwtUtil.getAuthenticationByToken(refreshToken);
         String newAccessToken = tokenGenerator.generateAccessToken(authentication);


### PR DESCRIPTION
Close #64 

JWT 내부적으로 type을 적용하여, Refresh Token이 필요한 순간에 Access Token을 사용할 수 없도록 수정하였습니다.

- 권한이 필요한 요청 토큰에 type이 ACCESS가 포함되어야 합니다.
- 토큰 재발급 시 type이 REFRESH인 토큰이 포함되어야 합니다.

`jwt.claims.type.name` 이 추가되었습니다.