### PR TITLE
모집 게시글 지원자 세부 지원 정보 조회

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/dto/ApplyDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/dto/ApplyDetails.java
@@ -1,0 +1,15 @@
+package com.dongsoop.dongsoop.recruitment.dto;
+
+import java.time.LocalDateTime;
+
+public record ApplyDetails(
+
+        Long boardId,
+        Long applierId,
+        String applierName,
+        String departmentName,
+        LocalDateTime applyTime,
+        String introduction,
+        String motivation
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectApplyController.java
@@ -47,6 +47,14 @@ public class ProjectApplyController {
         return ResponseEntity.ok(applyDetails);
     }
 
+    @GetMapping("/self/{boardId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetailsBySelf(@PathVariable("boardId") @Positive Long boardId) {
+        ApplyDetails applyDetails = projectApplyService.getRecruitmentApplyDetails(boardId);
+
+        return ResponseEntity.ok(applyDetails);
+    }
+
     @PostMapping
     @Secured(value = RoleType.USER_ROLE)
     public ResponseEntity<Void> applyProjectBoard(@RequestBody ApplyProjectBoardRequest applyProjectBoardRequest) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/controller/ProjectApplyController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.project.controller;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.project.dto.ApplyProjectBoardRequest;
@@ -35,6 +36,15 @@ public class ProjectApplyController {
                 boardId);
 
         return ResponseEntity.ok(overviewList);
+    }
+
+    @GetMapping("/{boardId}/applier/{applierId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetails(@PathVariable("boardId") @Positive Long boardId,
+                                                        @PathVariable("applierId") @Positive Long applierId) {
+        ApplyDetails applyDetails = projectApplyService.getRecruitmentApplyDetails(boardId, applierId);
+
+        return ResponseEntity.ok(applyDetails);
     }
 
     @PostMapping

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/exception/ProjectApplyNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/exception/ProjectApplyNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.recruitment.project.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ProjectApplyNotFoundException extends CustomException {
+
+    public ProjectApplyNotFoundException(Long boardId, Long applierId) {
+        super(boardId + " 게시글에 대해 " + applierId + " 지원자가 지원한 기록이 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.dongsoop.dongsoop.recruitment.project.repository;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
+import java.util.Optional;
 
 public interface ProjectApplyRepositoryCustom {
 
     boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
 
     void updateApplyStatus(Long memberId, Long boardId, RecruitmentApplyStatus status);
+
+    Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
@@ -1,8 +1,13 @@
 package com.dongsoop.dongsoop.recruitment.project.repository;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
 import com.dongsoop.dongsoop.recruitment.project.entity.QProjectApply;
+import com.dongsoop.dongsoop.recruitment.projection.ProjectRecruitmentProjection;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,8 +16,12 @@ import org.springframework.stereotype.Repository;
 public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryCustom {
 
     private static final QProjectApply projectApply = QProjectApply.projectApply;
+    private static final QMember member = QMember.member;
+    private static final QDepartment department = QDepartment.department;
 
     private final JPAQueryFactory queryFactory;
+
+    private final ProjectRecruitmentProjection projectRecruitmentProjection;
 
     @Override
     public boolean existsByBoardIdAndMemberId(Long boardId, Long memberId) {
@@ -30,5 +39,18 @@ public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryC
                         .and(projectApply.id.member.id.eq(memberId)))
                 .set(projectApply.status, status)
                 .execute();
+    }
+
+    @Override
+    public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
+        ApplyDetails result = queryFactory.select(projectRecruitmentProjection.getApplyDetailsExpression())
+                .from(projectApply)
+                .leftJoin(projectApply.id.member, member)
+                .leftJoin(member.department, department)
+                .where(projectApply.id.projectBoard.id.eq(boardId)
+                        .and(projectApply.id.member.id.eq(applierId)))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/repository/ProjectApplyRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
 import com.dongsoop.dongsoop.recruitment.project.entity.QProjectApply;
+import com.dongsoop.dongsoop.recruitment.project.entity.QProjectBoard;
 import com.dongsoop.dongsoop.recruitment.projection.ProjectRecruitmentProjection;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Repository;
 public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryCustom {
 
     private static final QProjectApply projectApply = QProjectApply.projectApply;
+    private static final QProjectBoard projectBoard = QProjectBoard.projectBoard;
     private static final QMember member = QMember.member;
     private static final QDepartment department = QDepartment.department;
 
@@ -45,6 +47,7 @@ public class ProjectApplyRepositoryCustomImpl implements ProjectApplyRepositoryC
     public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
         ApplyDetails result = queryFactory.select(projectRecruitmentProjection.getApplyDetailsExpression())
                 .from(projectApply)
+                .leftJoin(projectApply.id.projectBoard, projectBoard)
                 .leftJoin(projectApply.id.member, member)
                 .leftJoin(member.department, department)
                 .where(projectApply.id.projectBoard.id.eq(boardId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyService.java
@@ -1,11 +1,14 @@
 package com.dongsoop.dongsoop.recruitment.project.service;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.project.dto.ApplyProjectBoardRequest;
 import java.util.List;
 
 public interface ProjectApplyService {
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
 
     void apply(ApplyProjectBoardRequest boardId);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyService.java
@@ -8,11 +8,13 @@ import java.util.List;
 
 public interface ProjectApplyService {
 
-    ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
-
     void apply(ApplyProjectBoardRequest boardId);
 
     void updateStatus(Long boardId, UpdateApplyStatusRequest request);
 
     List<RecruitmentApplyOverview> getRecruitmentApplyOverview(Long boardId);
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -123,7 +123,7 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
 
         // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
         if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+                && !projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new ProjectBoardNotFound(boardId);
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -121,7 +121,7 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
         if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)
                 && !projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new ProjectBoardNotFound(boardId);

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -22,7 +22,6 @@ import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyReposito
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardRepository;
-import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardNotFound;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -122,9 +121,10 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이 아닐 경우 확인할 수 없다.
-        if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
-            throw new TutoringBoardNotFound(boardId, authorId);
+        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)
+                && !projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+            throw new ProjectBoardNotFound(boardId);
         }
 
         return projectApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -22,6 +22,7 @@ import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyReposito
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.project.repository.ProjectBoardRepository;
+import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardNotFound;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -119,6 +120,13 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
 
     @Override
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        Long authorId = memberService.getMemberIdByAuthentication();
+
+        // 게시물 주인이 아닐 경우 확인할 수 없다.
+        if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
+            throw new TutoringBoardNotFound(boardId, authorId);
+        }
+
         return projectApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new ProjectApplyNotFoundException(boardId, applierId));
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
@@ -12,6 +13,7 @@ import com.dongsoop.dongsoop.recruitment.project.entity.ProjectApply;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectApply.ProjectApplyKey;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoard;
 import com.dongsoop.dongsoop.recruitment.project.entity.ProjectBoardDepartment;
+import com.dongsoop.dongsoop.recruitment.project.exception.ProjectApplyNotFoundException;
 import com.dongsoop.dongsoop.recruitment.project.exception.ProjectBoardDepartmentMismatchException;
 import com.dongsoop.dongsoop.recruitment.project.exception.ProjectBoardDepartmentNotAssignedException;
 import com.dongsoop.dongsoop.recruitment.project.exception.ProjectBoardNotFound;
@@ -113,5 +115,11 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
         }
 
         return projectApplyRepository.findApplyOverviewByBoardId(boardId, requesterId);
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        return projectApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
+                .orElseThrow(() -> new ProjectApplyNotFoundException(boardId, applierId));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/project/service/ProjectApplyServiceImpl.java
@@ -121,13 +121,20 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
-        if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !projectApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
+        // 게시물 주인이 아닌 경우 예외
+        if (!projectBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
             throw new ProjectBoardNotFound(boardId);
         }
 
         return projectApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new ProjectApplyNotFoundException(boardId, applierId));
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId) {
+        Long requester = memberService.getMemberIdByAuthentication();
+
+        return projectApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, requester)
+                .orElseThrow(() -> new ProjectApplyNotFoundException(boardId, requester));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/ProjectRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/ProjectRecruitmentProjection.java
@@ -2,8 +2,6 @@ package com.dongsoop.dongsoop.recruitment.projection;
 
 import com.dongsoop.dongsoop.department.entity.QDepartment;
 import com.dongsoop.dongsoop.member.entity.QMember;
-import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
@@ -13,10 +11,7 @@ import com.dongsoop.dongsoop.recruitment.project.entity.QProjectBoard;
 import com.dongsoop.dongsoop.recruitment.project.entity.QProjectBoardDepartment;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,47 +22,6 @@ public class ProjectRecruitmentProjection implements RecruitmentProjection {
     private static final QProjectBoardDepartment boardDepartment = QProjectBoardDepartment.projectBoardDepartment;
     private static final QDepartment department = QDepartment.department;
     private static final QMember member = QMember.member;
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                JPAExpressions.select(apply.id.member.countDistinct().intValue())
-                        .from(apply)
-                        .where(board.id.eq(apply.id.projectBoard.id)),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                Expressions.stringTemplate("string_agg({0}, ',')",
-                        boardDepartment.id.department.id),
-                Expressions.constant(RecruitmentType.PROJECT),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getOpenedRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                apply.id.member.countDistinct().intValue(),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                Expressions.stringTemplate("string_agg({0}, ',')",
-                        boardDepartment.id.department.id),
-                Expressions.constant(RecruitmentType.PROJECT),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    private BooleanExpression isRecruiting() {
-        return board.endAt.gt(LocalDateTime.now())
-                .and(board.startAt.lt(LocalDateTime.now()));
-    }
 
     @Override
     public ConstructorExpression<RecruitmentOverview> getRecruitmentOverviewExpression() {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/ProjectRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/ProjectRecruitmentProjection.java
@@ -1,8 +1,11 @@
 package com.dongsoop.dongsoop.recruitment.projection;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.project.entity.QProjectApply;
@@ -22,6 +25,8 @@ public class ProjectRecruitmentProjection implements RecruitmentProjection {
     private static final QProjectBoard board = QProjectBoard.projectBoard;
     private static final QProjectApply apply = QProjectApply.projectApply;
     private static final QProjectBoardDepartment boardDepartment = QProjectBoardDepartment.projectBoardDepartment;
+    private static final QDepartment department = QDepartment.department;
+    private static final QMember member = QMember.member;
 
     @Override
     public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
@@ -95,5 +100,17 @@ public class ProjectRecruitmentProjection implements RecruitmentProjection {
                 apply.id.member.count().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
+    }
+
+    @Override
+    public ConstructorExpression<ApplyDetails> getApplyDetailsExpression() {
+        return Projections.constructor(ApplyDetails.class,
+                board.id,
+                member.id,
+                member.nickname,
+                department.name,
+                apply.applyTime,
+                apply.introduction,
+                apply.motivation);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/RecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/RecruitmentProjection.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.recruitment.projection;
 
 import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentOverview;
 import com.querydsl.core.types.ConstructorExpression;
@@ -16,4 +17,6 @@ public interface RecruitmentProjection {
 
     ConstructorExpression<RecruitmentDetails> getRecruitmentDetailsExpression(RecruitmentViewType viewType,
                                                                               boolean isAlreadyApplied);
+
+    ConstructorExpression<ApplyDetails> getApplyDetailsExpression();
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/RecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/RecruitmentProjection.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.recruitment.projection;
 
-import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
@@ -8,10 +7,6 @@ import com.dongsoop.dongsoop.recruitment.dto.RecruitmentOverview;
 import com.querydsl.core.types.ConstructorExpression;
 
 public interface RecruitmentProjection {
-
-    ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression();
-
-    ConstructorExpression<MyRecruitmentOverview> getOpenedRecruitmentExpression();
 
     ConstructorExpression<RecruitmentOverview> getRecruitmentOverviewExpression();
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/StudyRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/StudyRecruitmentProjection.java
@@ -2,8 +2,6 @@ package com.dongsoop.dongsoop.recruitment.projection;
 
 import com.dongsoop.dongsoop.department.entity.QDepartment;
 import com.dongsoop.dongsoop.member.entity.QMember;
-import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
@@ -13,10 +11,7 @@ import com.dongsoop.dongsoop.recruitment.study.entity.QStudyBoard;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyBoardDepartment;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,47 +22,6 @@ public class StudyRecruitmentProjection implements RecruitmentProjection {
     private static final QStudyBoardDepartment boardDepartment = QStudyBoardDepartment.studyBoardDepartment;
     private static final QMember member = QMember.member;
     private static final QDepartment department = QDepartment.department;
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                JPAExpressions.select(apply.id.member.countDistinct().intValue())
-                        .from(apply)
-                        .where(board.id.eq(apply.id.studyBoard.id)),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                Expressions.stringTemplate("string_agg({0}, ',')",
-                        boardDepartment.id.department.id),
-                Expressions.constant(RecruitmentType.PROJECT),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getOpenedRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                apply.id.member.countDistinct().intValue(),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                Expressions.stringTemplate("string_agg({0}, ',')",
-                        boardDepartment.id.department.id),
-                Expressions.constant(RecruitmentType.STUDY),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    private BooleanExpression isRecruiting() {
-        return board.endAt.gt(LocalDateTime.now())
-                .and(board.startAt.lt(LocalDateTime.now()));
-    }
 
     @Override
     public ConstructorExpression<RecruitmentOverview> getRecruitmentOverviewExpression() {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/StudyRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/StudyRecruitmentProjection.java
@@ -1,8 +1,11 @@
 package com.dongsoop.dongsoop.recruitment.projection;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
@@ -22,6 +25,8 @@ public class StudyRecruitmentProjection implements RecruitmentProjection {
     private static final QStudyBoard board = QStudyBoard.studyBoard;
     private static final QStudyApply apply = QStudyApply.studyApply;
     private static final QStudyBoardDepartment boardDepartment = QStudyBoardDepartment.studyBoardDepartment;
+    private static final QMember member = QMember.member;
+    private static final QDepartment department = QDepartment.department;
 
     @Override
     public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
@@ -95,5 +100,17 @@ public class StudyRecruitmentProjection implements RecruitmentProjection {
                 apply.id.member.count().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
+    }
+
+    @Override
+    public ConstructorExpression<ApplyDetails> getApplyDetailsExpression() {
+        return Projections.constructor(ApplyDetails.class,
+                board.id,
+                member.id,
+                member.nickname,
+                department.name,
+                apply.applyTime,
+                apply.introduction,
+                apply.motivation);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/TutoringRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/TutoringRecruitmentProjection.java
@@ -2,8 +2,6 @@ package com.dongsoop.dongsoop.recruitment.projection;
 
 import com.dongsoop.dongsoop.department.entity.QDepartment;
 import com.dongsoop.dongsoop.member.entity.QMember;
-import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
 import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
@@ -12,10 +10,7 @@ import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringBoard;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,45 +20,6 @@ public class TutoringRecruitmentProjection implements RecruitmentProjection {
     private static final QTutoringApply apply = QTutoringApply.tutoringApply;
     private static final QMember member = QMember.member;
     private static final QDepartment department = QDepartment.department;
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                JPAExpressions.select(apply.id.member.countDistinct().intValue())
-                        .from(apply)
-                        .where(board.id.eq(apply.id.tutoringBoard.id)),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                board.department.id.stringValue(),
-                Expressions.constant(RecruitmentType.TUTORING),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    @Override
-    public ConstructorExpression<MyRecruitmentOverview> getOpenedRecruitmentExpression() {
-        return Projections.constructor(MyRecruitmentOverview.class,
-                board.id,
-                apply.id.member.countDistinct().intValue(),
-                board.startAt,
-                board.endAt,
-                board.title,
-                board.content,
-                board.tags,
-                board.department.id.stringValue(),
-                Expressions.constant(RecruitmentType.TUTORING),
-                board.createdAt,
-                isRecruiting());
-    }
-
-    private BooleanExpression isRecruiting() {
-        return board.endAt.gt(LocalDateTime.now())
-                .and(board.startAt.lt(LocalDateTime.now()));
-    }
 
     @Override
     public ConstructorExpression<RecruitmentOverview> getRecruitmentOverviewExpression() {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/projection/TutoringRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/projection/TutoringRecruitmentProjection.java
@@ -1,8 +1,11 @@
 package com.dongsoop.dongsoop.recruitment.projection;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.mypage.dto.MyRecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import com.dongsoop.dongsoop.recruitment.RecruitmentViewType;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentOverview;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
@@ -20,6 +23,8 @@ public class TutoringRecruitmentProjection implements RecruitmentProjection {
 
     private static final QTutoringBoard board = QTutoringBoard.tutoringBoard;
     private static final QTutoringApply apply = QTutoringApply.tutoringApply;
+    private static final QMember member = QMember.member;
+    private static final QDepartment department = QDepartment.department;
 
     @Override
     public ConstructorExpression<MyRecruitmentOverview> getApplyRecruitmentExpression() {
@@ -90,5 +95,17 @@ public class TutoringRecruitmentProjection implements RecruitmentProjection {
                 apply.id.member.count().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
+    }
+
+    @Override
+    public ConstructorExpression<ApplyDetails> getApplyDetailsExpression() {
+        return Projections.constructor(ApplyDetails.class,
+                board.id,
+                member.id,
+                member.nickname,
+                department.name,
+                apply.applyTime,
+                apply.introduction,
+                apply.motivation);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyApplyController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.study.controller;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.study.dto.ApplyStudyBoardRequest;
@@ -35,6 +36,15 @@ public class StudyApplyController {
                 boardId);
 
         return ResponseEntity.ok(overviewList);
+    }
+
+    @GetMapping("/{boardId}/applier/{applierId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetails(@PathVariable("boardId") @Positive Long boardId,
+                                                        @PathVariable("applierId") @Positive Long applierId) {
+        ApplyDetails applyDetails = studyApplyService.getRecruitmentApplyDetails(boardId, applierId);
+
+        return ResponseEntity.ok(applyDetails);
     }
 
     @PostMapping

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/controller/StudyApplyController.java
@@ -47,6 +47,14 @@ public class StudyApplyController {
         return ResponseEntity.ok(applyDetails);
     }
 
+    @GetMapping("/self/{boardId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetailsBySelf(@PathVariable("boardId") @Positive Long boardId) {
+        ApplyDetails applyDetails = studyApplyService.getRecruitmentApplyDetails(boardId);
+
+        return ResponseEntity.ok(applyDetails);
+    }
+
     @PostMapping
     @Secured(value = RoleType.USER_ROLE)
     public ResponseEntity<Void> applyTutoringBoard(@RequestBody ApplyStudyBoardRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/exception/StudyApplyNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/exception/StudyApplyNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.recruitment.study.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class StudyApplyNotFoundException extends CustomException {
+
+    public StudyApplyNotFoundException(Long boardId, Long applierId) {
+        super(boardId + " 게시글에 대해 " + applierId + " 지원자가 지원한 기록이 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.dongsoop.dongsoop.recruitment.study.repository;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
+import java.util.Optional;
 
 public interface StudyApplyRepositoryCustom {
 
     boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
 
     void updateApplyStatus(Long memberId, Long boardId, RecruitmentApplyStatus status);
+
+    Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
 import com.dongsoop.dongsoop.recruitment.projection.StudyRecruitmentProjection;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
+import com.dongsoop.dongsoop.recruitment.study.entity.QStudyBoard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Repository;
 public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCustom {
 
     private static final QStudyApply studyApply = QStudyApply.studyApply;
+    private static final QStudyBoard studyBoard = QStudyBoard.studyBoard;
     private static final QMember member = QMember.member;
     private static final QDepartment department = QDepartment.department;
 
@@ -45,6 +47,7 @@ public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCusto
     public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
         ApplyDetails result = queryFactory.select(studyRecruitmentProjection.getApplyDetailsExpression())
                 .from(studyApply)
+                .leftJoin(studyApply.id.studyBoard, studyBoard)
                 .leftJoin(studyApply.id.member, member)
                 .leftJoin(member.department, department)
                 .where(studyApply.id.studyBoard.id.eq(boardId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/repository/StudyApplyRepositoryCustomImpl.java
@@ -1,8 +1,13 @@
 package com.dongsoop.dongsoop.recruitment.study.repository;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
+import com.dongsoop.dongsoop.recruitment.projection.StudyRecruitmentProjection;
 import com.dongsoop.dongsoop.recruitment.study.entity.QStudyApply;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +16,10 @@ import org.springframework.stereotype.Repository;
 public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCustom {
 
     private static final QStudyApply studyApply = QStudyApply.studyApply;
+    private static final QMember member = QMember.member;
+    private static final QDepartment department = QDepartment.department;
+
+    private final StudyRecruitmentProjection studyRecruitmentProjection;
 
     private final JPAQueryFactory queryFactory;
 
@@ -30,5 +39,18 @@ public class StudyApplyRepositoryCustomImpl implements StudyApplyRepositoryCusto
                         .and(studyApply.id.member.id.eq(memberId)))
                 .set(studyApply.status, status)
                 .execute();
+    }
+
+    @Override
+    public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
+        ApplyDetails result = queryFactory.select(studyRecruitmentProjection.getApplyDetailsExpression())
+                .from(studyApply)
+                .leftJoin(studyApply.id.member, member)
+                .leftJoin(member.department, department)
+                .where(studyApply.id.studyBoard.id.eq(boardId)
+                        .and(studyApply.id.member.id.eq(applierId)))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyService.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.study.service;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.study.dto.ApplyStudyBoardRequest;
@@ -12,4 +13,6 @@ public interface StudyApplyService {
     void updateStatus(Long boardId, UpdateApplyStatusRequest request);
 
     List<RecruitmentApplyOverview> getRecruitmentApplyOverview(Long boardId);
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyService.java
@@ -15,4 +15,6 @@ public interface StudyApplyService {
     List<RecruitmentApplyOverview> getRecruitmentApplyOverview(Long boardId);
 
     ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -123,7 +123,7 @@ public class StudyApplyServiceImpl implements StudyApplyService {
 
         // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
         if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+                && !studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new StudyBoardNotFound(boardId);
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -121,7 +121,7 @@ public class StudyApplyServiceImpl implements StudyApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
         if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)
                 && !studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new StudyBoardNotFound(boardId);

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -22,7 +22,6 @@ import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardRepository;
-import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardNotFound;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -122,9 +121,10 @@ public class StudyApplyServiceImpl implements StudyApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이 아닐 경우 확인할 수 없다.
-        if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
-            throw new TutoringBoardNotFound(boardId, authorId);
+        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)
+                && !studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+            throw new StudyBoardNotFound(boardId);
         }
 
         return studyApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
@@ -12,6 +13,7 @@ import com.dongsoop.dongsoop.recruitment.study.entity.StudyApply;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyApply.StudyApplyKey;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoard;
 import com.dongsoop.dongsoop.recruitment.study.entity.StudyBoardDepartment;
+import com.dongsoop.dongsoop.recruitment.study.exception.StudyApplyNotFoundException;
 import com.dongsoop.dongsoop.recruitment.study.exception.StudyBoardDepartmentMismatchException;
 import com.dongsoop.dongsoop.recruitment.study.exception.StudyBoardDepartmentNotAssignedException;
 import com.dongsoop.dongsoop.recruitment.study.exception.StudyBoardNotFound;
@@ -113,5 +115,11 @@ public class StudyApplyServiceImpl implements StudyApplyService {
         }
 
         return studyApplyRepository.findApplyOverviewByBoardId(boardId, requesterId);
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        return studyApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
+                .orElseThrow(() -> new StudyApplyNotFoundException(boardId, applierId));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -119,15 +119,22 @@ public class StudyApplyServiceImpl implements StudyApplyService {
 
     @Override
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
-        Long authorId = memberService.getMemberIdByAuthentication();
+        Long requester = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
-        if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !studyApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
+        // 게시물 주인이 아닌 경우 예외
+        if (!studyBoardRepository.existsByIdAndAuthorId(boardId, requester)) {
             throw new StudyBoardNotFound(boardId);
         }
 
         return studyApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new StudyApplyNotFoundException(boardId, applierId));
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId) {
+        Long requester = memberService.getMemberIdByAuthentication();
+
+        return studyApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, requester)
+                .orElseThrow(() -> new StudyApplyNotFoundException(boardId, requester));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/study/service/StudyApplyServiceImpl.java
@@ -22,6 +22,7 @@ import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyApplyRepositoryCustom;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.study.repository.StudyBoardRepository;
+import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardNotFound;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -119,6 +120,13 @@ public class StudyApplyServiceImpl implements StudyApplyService {
 
     @Override
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        Long authorId = memberService.getMemberIdByAuthentication();
+
+        // 게시물 주인이 아닐 경우 확인할 수 없다.
+        if (!studyBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
+            throw new TutoringBoardNotFound(boardId, authorId);
+        }
+
         return studyApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new StudyApplyNotFoundException(boardId, applierId));
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringApplyController.java
@@ -47,6 +47,14 @@ public class TutoringApplyController {
         return ResponseEntity.ok(applyDetails);
     }
 
+    @GetMapping("/self/{boardId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetailsBySelf(@PathVariable("boardId") @Positive Long boardId) {
+        ApplyDetails applyDetails = tutoringApplyService.getRecruitmentApplyDetails(boardId);
+
+        return ResponseEntity.ok(applyDetails);
+    }
+
     @PostMapping
     @Secured(value = RoleType.USER_ROLE)
     public ResponseEntity<Void> applyTutoringBoard(@RequestBody ApplyTutoringBoardRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringApplyController.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/controller/TutoringApplyController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.controller;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.ApplyTutoringBoardRequest;
@@ -35,6 +36,15 @@ public class TutoringApplyController {
                 boardId);
 
         return ResponseEntity.ok(overviewList);
+    }
+
+    @GetMapping("/{boardId}/applier/{applierId}")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<ApplyDetails> getApplyDetails(@PathVariable("boardId") @Positive Long boardId,
+                                                        @PathVariable("applierId") @Positive Long applierId) {
+        ApplyDetails applyDetails = tutoringApplyService.getRecruitmentApplyDetails(boardId, applierId);
+
+        return ResponseEntity.ok(applyDetails);
     }
 
     @PostMapping

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/exception/TutoringApplyNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/exception/TutoringApplyNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.recruitment.tutoring.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class TutoringApplyNotFoundException extends CustomException {
+
+    public TutoringApplyNotFoundException(Long boardId, Long applierId) {
+        super(boardId + " 게시글에 대해 " + applierId + " 지원자가 지원한 기록이 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
+import java.util.Optional;
 
 public interface TutoringApplyRepositoryCustom {
 
     boolean existsByBoardIdAndMemberId(Long boardId, Long member);
 
     void updateApplyStatus(Long memberId, Long boardId, RecruitmentApplyStatus status);
+
+    Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
 import com.dongsoop.dongsoop.recruitment.projection.TutoringRecruitmentProjection;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
+import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringBoard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Repository;
 public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositoryCustom {
 
     private static final QTutoringApply tutoringApply = QTutoringApply.tutoringApply;
+    private static final QTutoringBoard tutoringBoard = QTutoringBoard.tutoringBoard;
     private static final QMember member = QMember.member;
     private static final QDepartment department = QDepartment.department;
 
@@ -45,6 +47,7 @@ public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositor
     public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
         ApplyDetails result = queryFactory.select(tutoringRecruitmentProjection.getApplyDetailsExpression())
                 .from(tutoringApply)
+                .leftJoin(tutoringApply.id.tutoringBoard, tutoringBoard)
                 .leftJoin(tutoringApply.id.member, member)
                 .leftJoin(member.department, department)
                 .where(tutoringApply.id.tutoringBoard.id.eq(boardId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/repository/TutoringApplyRepositoryCustomImpl.java
@@ -1,8 +1,13 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.repository;
 
+import com.dongsoop.dongsoop.department.entity.QDepartment;
+import com.dongsoop.dongsoop.member.entity.QMember;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
+import com.dongsoop.dongsoop.recruitment.projection.TutoringRecruitmentProjection;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.QTutoringApply;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +16,10 @@ import org.springframework.stereotype.Repository;
 public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositoryCustom {
 
     private static final QTutoringApply tutoringApply = QTutoringApply.tutoringApply;
+    private static final QMember member = QMember.member;
+    private static final QDepartment department = QDepartment.department;
+
+    private final TutoringRecruitmentProjection tutoringRecruitmentProjection;
 
     private final JPAQueryFactory queryFactory;
 
@@ -30,5 +39,18 @@ public class TutoringApplyRepositoryCustomImpl implements TutoringApplyRepositor
                         .and(tutoringApply.id.member.id.eq(memberId)))
                 .set(tutoringApply.status, status)
                 .execute();
+    }
+
+    @Override
+    public Optional<ApplyDetails> findApplyDetailsByBoardIdAndApplierId(Long boardId, Long applierId) {
+        ApplyDetails result = queryFactory.select(tutoringRecruitmentProjection.getApplyDetailsExpression())
+                .from(tutoringApply)
+                .leftJoin(tutoringApply.id.member, member)
+                .leftJoin(member.department, department)
+                .where(tutoringApply.id.tutoringBoard.id.eq(boardId)
+                        .and(tutoringApply.id.member.id.eq(applierId)))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyService.java
@@ -15,4 +15,6 @@ public interface TutoringApplyService {
     List<RecruitmentApplyOverview> getRecruitmentApplyOverview(Long boardId);
 
     ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
+    
+    ApplyDetails getRecruitmentApplyDetails(Long boardId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyService.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyService.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.tutoring.service;
 
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.tutoring.dto.ApplyTutoringBoardRequest;
@@ -12,4 +13,6 @@ public interface TutoringApplyService {
     void updateStatus(Long boardId, UpdateApplyStatusRequest request);
 
     List<RecruitmentApplyOverview> getRecruitmentApplyOverview(Long boardId);
+
+    ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -99,7 +99,7 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
         if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)
                 && !tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new TutoringBoardNotFound(boardId);

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -101,7 +101,7 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
 
         // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
         if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+                && !tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
             throw new TutoringBoardNotFound(boardId);
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -97,6 +97,13 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
 
     @Override
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        Long authorId = memberService.getMemberIdByAuthentication();
+
+        // 게시물 주인이 아닐 경우 확인할 수 없다.
+        if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
+            throw new TutoringBoardNotFound(boardId, authorId);
+        }
+
         return tutoringApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new TutoringApplyNotFoundException(boardId, applierId));
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -99,9 +99,10 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
         Long authorId = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인이 아닐 경우 확인할 수 없다.
-        if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)) {
-            throw new TutoringBoardNotFound(boardId, authorId);
+        // 게시물 주인이거나 지원자가 아닐 경우 확인할 수 없다.
+        if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)
+                && !tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, authorId)) {
+            throw new TutoringBoardNotFound(boardId);
         }
 
         return tutoringApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -97,15 +97,22 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
 
     @Override
     public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
-        Long authorId = memberService.getMemberIdByAuthentication();
+        Long requester = memberService.getMemberIdByAuthentication();
 
-        // 게시물 주인도 아니면서 지원자도 아닌 경우 확인할 수 없다.
-        if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, authorId)
-                && !tutoringApplyRepositoryCustom.existsByBoardIdAndMemberId(boardId, applierId)) {
+        // 게시물 주인이 아닌 경우 예외
+        if (!tutoringBoardRepository.existsByIdAndAuthorId(boardId, requester)) {
             throw new TutoringBoardNotFound(boardId);
         }
 
         return tutoringApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
                 .orElseThrow(() -> new TutoringApplyNotFoundException(boardId, applierId));
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId) {
+        Long requester = memberService.getMemberIdByAuthentication();
+
+        return tutoringApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, requester)
+                .orElseThrow(() -> new TutoringApplyNotFoundException(boardId, requester));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/tutoring/service/TutoringApplyServiceImpl.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.recruitment.tutoring.service;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.recruitment.dto.ApplyDetails;
 import com.dongsoop.dongsoop.recruitment.dto.RecruitmentApplyOverview;
 import com.dongsoop.dongsoop.recruitment.dto.UpdateApplyStatusRequest;
 import com.dongsoop.dongsoop.recruitment.entity.RecruitmentApplyStatus;
@@ -10,6 +11,7 @@ import com.dongsoop.dongsoop.recruitment.tutoring.dto.ApplyTutoringBoardRequest;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringApply;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringApply.TutoringApplyKey;
 import com.dongsoop.dongsoop.recruitment.tutoring.entity.TutoringBoard;
+import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringApplyNotFoundException;
 import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardDepartmentMismatchException;
 import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.recruitment.tutoring.exception.TutoringRecruitmentAlreadyAppliedException;
@@ -91,5 +93,11 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
         }
 
         return tutoringApplyRepository.findApplyOverviewByBoardId(boardId, requesterId);
+    }
+
+    @Override
+    public ApplyDetails getRecruitmentApplyDetails(Long boardId, Long applierId) {
+        return tutoringApplyRepositoryCustom.findApplyDetailsByBoardIdAndApplierId(boardId, applierId)
+                .orElseThrow(() -> new TutoringApplyNotFoundException(boardId, applierId));
     }
 }


### PR DESCRIPTION
Close #113 

## 기능 설명(Description)

개설한 모집 글에 대해 지원한 지원자의 닉네임과 같은 회원 정보를 비롯하여  
지원 시 작성한 자기소개, 지원동기를 반환합니다.

## 구현해야 할 세부 항목(Tasks/Checklist)

- [x] 이 세부 정보를 조회하는 사람은 게시글 주인이거나 지원자여야 한다.
- [x] 게시물 id와 지원자 id를 통해 DB에서 지원자 정보를 조회한다.
- [x] 사용되지 않는 Projection 메서드 제거
   - 통합 조회 메서드가 UNION 메서드 사용으로 인해 JpaRepository에서 관리되기 때문에 Projection이 의미가 사라짐 