### PR TITLE
회원탈퇴 불가 문제 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -195,12 +195,28 @@ public class MemberServiceImpl implements MemberService {
         Long requesterId = getMemberIdByAuthentication();
 
         // 가명처리
-        String emailAlias = UUID.randomUUID().toString().replace("-", "");
-        String passwordAlias = passwordEncoder.encode(UUID.randomUUID().toString());
+        String emailAlias = generateEmailAlias();
+        String passwordAlias = generatePasswordAlias();
         long updatedCount = memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
         if (updatedCount == 0L) {
             log.error("Member with id {} not found or already deleted", requesterId);
             throw new MemberNotFoundException();
         }
+    }
+
+    private String generateEmailAlias() {
+        return generateRawUUID();
+    }
+
+    private String generatePasswordAlias() {
+        String uuid = generateRawUUID();
+
+        return passwordEncoder.encode(uuid);
+    }
+
+    private String generateRawUUID() {
+        return UUID.randomUUID()
+                .toString()
+                .replace("-", "");
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -195,7 +195,7 @@ public class MemberServiceImpl implements MemberService {
         Long requesterId = getMemberIdByAuthentication();
 
         // 가명처리
-        String emailAlias = passwordEncoder.encode(UUID.randomUUID().toString());
+        String emailAlias = UUID.randomUUID().toString().replace("-", "");
         String passwordAlias = passwordEncoder.encode(UUID.randomUUID().toString());
         long updatedCount = memberRepositoryCustom.softDelete(requesterId, emailAlias, passwordAlias);
         if (updatedCount == 0L) {


### PR DESCRIPTION
회원 탈퇴 시 가명처리 과정에서 DB에 제한된 범위를 넘는 가명을 저장하여 쿼리 에러가 발생하는 문제를 해결했습니다.  

> 이메일은 50글자 제한이지만, 기존 인코딩 방식은 60글자를 제한했었습니다.

```java
String emailAlias = passwordEncoder.encode(UUID.randomUUID().toString());
String emailAlias = UUID.randomUUID().toString().replace("-", "");
```