### PR TITLE
필터 토큰 검증 로직 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
@@ -44,7 +44,7 @@ public class JwtUtil {
                     .getPayload();
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException(e);
-        } catch (MalformedJwtException e) {
+        } catch (MalformedJwtException | IllegalArgumentException e) {
             throw new TokenMalformedException(e);
         } catch (SignatureException e) {
             throw new TokenSignatureException(e);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
@@ -3,10 +3,12 @@ package com.dongsoop.dongsoop.jwt;
 import com.dongsoop.dongsoop.jwt.dto.AuthenticationInformationByToken;
 import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
 import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
+import com.dongsoop.dongsoop.jwt.exception.TokenSignatureException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -44,6 +46,8 @@ public class JwtUtil {
             throw new TokenExpiredException(e);
         } catch (MalformedJwtException e) {
             throw new TokenMalformedException(e);
+        } catch (SignatureException e) {
+            throw new TokenSignatureException();
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
@@ -47,7 +47,7 @@ public class JwtUtil {
         } catch (MalformedJwtException e) {
             throw new TokenMalformedException(e);
         } catch (SignatureException e) {
-            throw new TokenSignatureException();
+            throw new TokenSignatureException(e);
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/JwtUtil.java
@@ -4,10 +4,12 @@ import com.dongsoop.dongsoop.jwt.dto.AuthenticationInformationByToken;
 import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
 import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
 import com.dongsoop.dongsoop.jwt.exception.TokenSignatureException;
+import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import java.util.Collection;
 import java.util.Date;
@@ -48,6 +50,8 @@ public class JwtUtil {
             throw new TokenMalformedException(e);
         } catch (SignatureException e) {
             throw new TokenSignatureException(e);
+        } catch (UnsupportedJwtException e) {
+            throw new TokenUnsupportedException(e);
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/JWTException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/JWTException.java
@@ -1,0 +1,23 @@
+package com.dongsoop.dongsoop.jwt.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class JWTException extends CustomException {
+
+    public JWTException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+
+    public JWTException(String message, HttpStatus httpStatus, Exception cause) {
+        super(message, httpStatus, cause);
+    }
+
+    public JWTException(String message, HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+
+    public JWTException(String message, Exception cause) {
+        super(message, HttpStatus.UNAUTHORIZED, cause);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotAccessTokenException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotAccessTokenException.java
@@ -1,11 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
-import org.springframework.http.HttpStatus;
-
-public class NotAccessTokenException extends CustomException {
+public class NotAccessTokenException extends JWTException {
 
     public NotAccessTokenException() {
-        super("액세스 토큰이 아닙니다.", HttpStatus.UNAUTHORIZED);
+        super("액세스 토큰이 아닙니다.");
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotRefreshTokenException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/NotRefreshTokenException.java
@@ -1,11 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
-import org.springframework.http.HttpStatus;
-
-public class NotRefreshTokenException extends CustomException {
+public class NotRefreshTokenException extends JWTException {
 
     public NotRefreshTokenException() {
-        super("리프레시 토큰이 아닙니다.", HttpStatus.UNAUTHORIZED);
+        super("리프레시 토큰이 아닙니다.");
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/RefreshTokenNotFoundException.java
@@ -1,9 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
-public class RefreshTokenNotFoundException extends CustomException {
+public class RefreshTokenNotFoundException extends JWTException {
 
     public RefreshTokenNotFoundException() {
         super("리프레시 토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenExpiredException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenExpiredException.java
@@ -1,16 +1,13 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
-import org.springframework.http.HttpStatus;
-
-public class TokenExpiredException extends CustomException {
+public class TokenExpiredException extends JWTException {
 
     public TokenExpiredException() {
-        super("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+        super("토큰이 만료되었습니다.");
     }
 
     public TokenExpiredException(Exception e) {
-        super("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED, e);
+        super("토큰이 만료되었습니다.", e);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenMalformedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenMalformedException.java
@@ -1,18 +1,13 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
-import org.springframework.http.HttpStatus;
-
-public class TokenMalformedException extends CustomException {
-
-    private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+public class TokenMalformedException extends JWTException {
 
     public TokenMalformedException() {
-        super("토큰이 올바르지 않습니다.", HTTP_STATUS);
+        super("토큰이 올바르지 않습니다.");
     }
 
     public TokenMalformedException(Exception e) {
-        super("토큰이 올바르지 않습니다.", HTTP_STATUS, e);
+        super("토큰이 올바르지 않습니다.", e);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenNotFoundException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenNotFoundException.java
@@ -1,9 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
-public class TokenNotFoundException extends CustomException {
+public class TokenNotFoundException extends JWTException {
 
     public TokenNotFoundException() {
         super("토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenRoleNotAvailableException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenRoleNotAvailableException.java
@@ -1,9 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
-public class TokenRoleNotAvailableException extends CustomException {
+public class TokenRoleNotAvailableException extends JWTException {
 
     public TokenRoleNotAvailableException() {
         super("토큰의 권한이 적절하지 않습니다.", HttpStatus.FORBIDDEN);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
@@ -1,15 +1,12 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
-import org.springframework.http.HttpStatus;
-
-public class TokenSignatureException extends CustomException {
+public class TokenSignatureException extends JWTException {
 
     public TokenSignatureException() {
-        super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
+        super("토큰의 서명이 올바르지 않습니다.");
     }
 
     public TokenSignatureException(Exception exception) {
-        super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, exception);
+        super("토큰의 서명이 올바르지 않습니다.", exception);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
@@ -5,8 +5,11 @@ import org.springframework.http.HttpStatus;
 
 public class TokenSignatureException extends CustomException {
 
+    public TokenSignatureException() {
+        super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
+    }
+
     public TokenSignatureException(Exception exception) {
         super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, exception);
     }
-
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenSignatureException.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public class TokenSignatureException extends CustomException {
 
-    public TokenSignatureException() {
-        super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
+    public TokenSignatureException(Exception exception) {
+        super("토큰의 서명이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, exception);
     }
 
 }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenUnsupportedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/exception/TokenUnsupportedException.java
@@ -1,9 +1,8 @@
 package com.dongsoop.dongsoop.jwt.exception;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
-public class TokenUnsupportedException extends CustomException {
+public class TokenUnsupportedException extends JWTException {
 
     public TokenUnsupportedException(Exception e) {
         super("지원하지 않는 JWT 형식입니다.", HttpStatus.BAD_REQUEST, e);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -62,7 +62,7 @@ public class JwtFilter extends OncePerRequestFilter {
             jwtValidator.validateAccessToken(claims);
             setAuthentication(token);
         } catch (TokenNotFoundException exception) {
-            log.info("Member doesn't have token: {}", exception.getMessage());
+            log.debug("Member doesn't have token: {}", exception.getMessage(), exception);
         } catch (TokenMalformedException | TokenExpiredException | NotAccessTokenException |
                  TokenSignatureException | TokenRoleNotAvailableException | TokenUnsupportedException exception) {
             log.error("Token validation failed: {}", exception.getMessage(), exception);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -58,7 +58,7 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (TokenNotFoundException exception) {
             log.info("Member doesn't have token: {}", exception.getMessage(), exception);
         } catch (Exception exception) {
-            log.info("Token validation failed: {}", exception.getMessage(), exception);
+            log.error("Token validation failed: {}", exception.getMessage(), exception);
             exceptionResolver.resolveException(request, response, null, exception);
             return;
         }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -1,15 +1,8 @@
 package com.dongsoop.dongsoop.jwt.filter;
 
-import com.dongsoop.dongsoop.common.exception.CustomException;
 import com.dongsoop.dongsoop.jwt.JwtUtil;
 import com.dongsoop.dongsoop.jwt.JwtValidator;
-import com.dongsoop.dongsoop.jwt.exception.NotAccessTokenException;
-import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
-import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
 import com.dongsoop.dongsoop.jwt.exception.TokenNotFoundException;
-import com.dongsoop.dongsoop.jwt.exception.TokenRoleNotAvailableException;
-import com.dongsoop.dongsoop.jwt.exception.TokenSignatureException;
-import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -62,14 +55,12 @@ public class JwtFilter extends OncePerRequestFilter {
             jwtValidator.validate(claims);
             jwtValidator.validateAccessToken(claims);
             setAuthentication(token);
-        } catch (TokenMalformedException | TokenNotFoundException | TokenExpiredException |
-                 TokenSignatureException | TokenRoleNotAvailableException | TokenUnsupportedException |
-                 NotAccessTokenException exception) {
-            log.error("JWT Filter processing failed with JWT exception: {}", exception.getMessage(), exception);
-        } catch (CustomException exception) {
-            log.error("JWT Filter processing failed with custom exception: {}", exception.getMessage(), exception);
+        } catch (TokenNotFoundException exception) {
+            log.error("Member doesn't have token: {}", exception.getMessage(), exception);
         } catch (Exception exception) {
-            log.error("JWT Filter processing failed with unknown exception: {}", exception.getMessage(), exception);
+            log.error("Token validation failed: {}", exception.getMessage(), exception);
+            exceptionResolver.resolveException(request, response, null, exception);
+            return;
         }
 
         try {

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -56,9 +56,9 @@ public class JwtFilter extends OncePerRequestFilter {
             jwtValidator.validateAccessToken(claims);
             setAuthentication(token);
         } catch (TokenNotFoundException exception) {
-            log.error("Member doesn't have token: {}", exception.getMessage(), exception);
+            log.info("Member doesn't have token: {}", exception.getMessage(), exception);
         } catch (Exception exception) {
-            log.error("Token validation failed: {}", exception.getMessage(), exception);
+            log.info("Token validation failed: {}", exception.getMessage(), exception);
             exceptionResolver.resolveException(request, response, null, exception);
             return;
         }

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -56,7 +56,7 @@ public class JwtFilter extends OncePerRequestFilter {
             jwtValidator.validateAccessToken(claims);
             setAuthentication(token);
         } catch (TokenNotFoundException exception) {
-            log.info("Member doesn't have token: {}", exception.getMessage(), exception);
+            log.info("Member doesn't have token: {}", exception.getMessage());
         } catch (Exception exception) {
             log.error("Token validation failed: {}", exception.getMessage(), exception);
             exceptionResolver.resolveException(request, response, null, exception);

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -2,13 +2,8 @@ package com.dongsoop.dongsoop.jwt.filter;
 
 import com.dongsoop.dongsoop.jwt.JwtUtil;
 import com.dongsoop.dongsoop.jwt.JwtValidator;
-import com.dongsoop.dongsoop.jwt.exception.NotAccessTokenException;
-import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
-import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
+import com.dongsoop.dongsoop.jwt.exception.JWTException;
 import com.dongsoop.dongsoop.jwt.exception.TokenNotFoundException;
-import com.dongsoop.dongsoop.jwt.exception.TokenRoleNotAvailableException;
-import com.dongsoop.dongsoop.jwt.exception.TokenSignatureException;
-import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,8 +58,7 @@ public class JwtFilter extends OncePerRequestFilter {
             setAuthentication(token);
         } catch (TokenNotFoundException exception) {
             log.debug("Member doesn't have token: {}", exception.getMessage(), exception);
-        } catch (TokenMalformedException | TokenExpiredException | NotAccessTokenException |
-                 TokenSignatureException | TokenRoleNotAvailableException | TokenUnsupportedException exception) {
+        } catch (JWTException exception) {
             log.error("Token validation failed: {}", exception.getMessage(), exception);
             exceptionResolver.resolveException(request, response, null, exception);
             return;

--- a/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/filter/JwtFilter.java
@@ -2,7 +2,13 @@ package com.dongsoop.dongsoop.jwt.filter;
 
 import com.dongsoop.dongsoop.jwt.JwtUtil;
 import com.dongsoop.dongsoop.jwt.JwtValidator;
+import com.dongsoop.dongsoop.jwt.exception.NotAccessTokenException;
+import com.dongsoop.dongsoop.jwt.exception.TokenExpiredException;
+import com.dongsoop.dongsoop.jwt.exception.TokenMalformedException;
 import com.dongsoop.dongsoop.jwt.exception.TokenNotFoundException;
+import com.dongsoop.dongsoop.jwt.exception.TokenRoleNotAvailableException;
+import com.dongsoop.dongsoop.jwt.exception.TokenSignatureException;
+import com.dongsoop.dongsoop.jwt.exception.TokenUnsupportedException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -57,7 +63,8 @@ public class JwtFilter extends OncePerRequestFilter {
             setAuthentication(token);
         } catch (TokenNotFoundException exception) {
             log.info("Member doesn't have token: {}", exception.getMessage());
-        } catch (Exception exception) {
+        } catch (TokenMalformedException | TokenExpiredException | NotAccessTokenException |
+                 TokenSignatureException | TokenRoleNotAvailableException | TokenUnsupportedException exception) {
             log.error("Token validation failed: {}", exception.getMessage(), exception);
             exceptionResolver.resolveException(request, response, null, exception);
             return;


### PR DESCRIPTION
필터에서 사용자 JWT 검증 시 토큰에 문제(만료, 시그니처 오류 등)가 있는 경우 401 예외를 발생시키도록 수정하였습니다.  
토큰이 존재하지 않는 경우는 여전히 `익명`사용자로 등록되어 컨트롤러 로직을 수행하며,  
토큰이 정상적인 경우에도 권한이 정상 등록되어 실행됩니다.