### PR TITLE
DB 조회 결과 중복 제거

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/dto/RecruitmentDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/dto/RecruitmentDetails.java
@@ -47,6 +47,7 @@ public record RecruitmentDetails(
         return Arrays.stream(departmentTypes.split(","))
                 .map(String::trim)
                 .map(DepartmentType::valueOf)
+                .distinct()
                 .toList();
     }
 }


### PR DESCRIPTION
모집 게시글 상세 조회 시 학과가 중복 조회되는 문제를 distinct() 메서드를 통해 해결하였습니다.  