### PR TITLE
Add ARM64 platform support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ secrets.DOCKER_USERNAME }}/spring-app:latest
     


### PR DESCRIPTION
aws ec2 -> amd64 환경
oracle 클라우드 -> arm64환경으로 인해 도커의 멀티 플랫폼을 이용하려고 ci/cd에 추가