### PR TITLE
지원자 중복 제거

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/ProjectRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/ProjectRecruitmentProjection.java
@@ -46,7 +46,7 @@ public class ProjectRecruitmentProjection implements RecruitmentProjection {
                 board.author.nickname,
                 board.createdAt,
                 board.updatedAt,
-                apply.id.member.count().intValue(),
+                apply.id.member.countDistinct().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/StudyRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/StudyRecruitmentProjection.java
@@ -46,7 +46,7 @@ public class StudyRecruitmentProjection implements RecruitmentProjection {
                 board.author.nickname,
                 board.createdAt,
                 board.updatedAt,
-                apply.id.member.count().intValue(),
+                apply.id.member.countDistinct().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
     }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/TutoringRecruitmentProjection.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/projection/TutoringRecruitmentProjection.java
@@ -20,7 +20,7 @@ public class TutoringRecruitmentProjection implements RecruitmentProjection {
     public ConstructorExpression<RecruitmentOverview> getRecruitmentOverviewExpression() {
         return Projections.constructor(RecruitmentOverview.class,
                 board.id,
-                apply.id.member.count().intValue(),
+                apply.id.member.countDistinct().intValue(),
                 board.startAt,
                 board.endAt,
                 board.title,
@@ -43,7 +43,7 @@ public class TutoringRecruitmentProjection implements RecruitmentProjection {
                 board.author.nickname,
                 board.createdAt.as("createdAt"),
                 board.updatedAt.as("updatedAt"),
-                apply.id.member.count().intValue(),
+                apply.id.member.countDistinct().intValue(),
                 Expressions.constant(viewType),
                 Expressions.constant(isAlreadyApplied));
     }


### PR DESCRIPTION
모집 게시글 조회 시 지원자 수가 중복 카운팅되는 것을 해결하였습니다.