### PR TITLE
모집 게시글 태그 필수 적용

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.board;
 
+import com.dongsoop.dongsoop.recruitment.validation.constant.RecruitmentValidationConstant;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,6 @@ public abstract class RecruitmentBoard extends Board {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
-    @Column(name = "tags", length = 100, nullable = false)
+    @Column(name = "tags", length = RecruitmentValidationConstant.TAG_MAX_LENGTH, nullable = false)
     private String tags;
 }

--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -20,6 +20,6 @@ public abstract class RecruitmentBoard extends Board {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
-    @Column(name = "tags", length = 100)
+    @Column(name = "tags", length = 100, nullable = false)
     private String tags;
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTag.java
@@ -3,8 +3,6 @@ package com.dongsoop.dongsoop.recruitment.validation.annotation;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import jakarta.validation.ReportAsSingleViolation;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,9 +10,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-@Pattern(regexp = "^[a-zA-Z0-9가-힣,]+$")
-@Size(max = 100)
-@Constraint(validatedBy = {})
+@Constraint(validatedBy = {BoardTagValidator.class})
 @ReportAsSingleViolation
 public @interface BoardTag {
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
@@ -1,17 +1,15 @@
 package com.dongsoop.dongsoop.recruitment.validation.annotation;
 
+import com.dongsoop.dongsoop.recruitment.validation.constant.RecruitmentValidationConstant;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import java.util.regex.Pattern;
 import org.springframework.util.StringUtils;
 
 public class BoardTagValidator implements ConstraintValidator<BoardTag, String> {
 
-    private static final int MAX_LENGTH = 100;
-    private static final Pattern TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣,]*[a-zA-Z0-9가-힣]+$");
-
     @Override
     public boolean isValid(String tags, ConstraintValidatorContext constraintValidatorContext) {
-        return StringUtils.hasText(tags) && tags.length() <= MAX_LENGTH && TAG_PATTERN.matcher(tags).matches();
+        return StringUtils.hasText(tags) && tags.length() <= RecruitmentValidationConstant.TAG_MAX_LENGTH
+                && RecruitmentValidationConstant.TAG_PATTERN.matcher(tags).matches();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
@@ -1,0 +1,17 @@
+package com.dongsoop.dongsoop.recruitment.validation.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+import org.springframework.util.StringUtils;
+
+public class BoardTagValidator implements ConstraintValidator<BoardTag, String> {
+
+    private static final int MAX_LENGTH = 100;
+    private static final Pattern TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣,]*[a-zA-Z0-9가-힣]+$");
+
+    @Override
+    public boolean isValid(String tags, ConstraintValidatorContext constraintValidatorContext) {
+        return StringUtils.hasText(tags) && tags.length() <= MAX_LENGTH && TAG_PATTERN.matcher(tags).matches();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/constant/RecruitmentValidationConstant.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/constant/RecruitmentValidationConstant.java
@@ -1,0 +1,18 @@
+package com.dongsoop.dongsoop.recruitment.validation.constant;
+
+import java.util.regex.Pattern;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class RecruitmentValidationConstant {
+
+    public static final int TAG_MAX_LENGTH = 100;
+
+    private static final String AVAILABLE_TAG_TEXT = "[a-zA-Z0-9가-힣]";
+    private static final String TAG_LENGTH_REGEX = "{1," + TAG_MAX_LENGTH + "}";
+    private static final String START_TAG_REGEX = AVAILABLE_TAG_TEXT + TAG_LENGTH_REGEX;
+    private static final String NEXT_TAG_PATTERN =
+            "(," + AVAILABLE_TAG_TEXT + TAG_LENGTH_REGEX + ")*";
+    public static final Pattern TAG_PATTERN = Pattern.compile(
+            "^" + START_TAG_REGEX + NEXT_TAG_PATTERN + "$");
+}


### PR DESCRIPTION
모집 게시글 생성 시 태그를 필수로 등록하도록 강제합니다.  

- 요청 시 `@Valid`를 통해 `태그,태그` 형태의 구조를 검사합니다.
- DB 저장 시 `nullable = false`를 통해 검사합니다.