### PR TITLE
신고자 정보 응답값 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/report/dto/CreateReportRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/dto/CreateReportRequest.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record CreateReportRequest(
-
         @NotNull(message = "신고 대상 타입은 필수입니다.")
         ReportType reportType,
 
@@ -19,6 +18,9 @@ public record CreateReportRequest(
         ReportReason reason,
 
         @Size(max = 500, message = "신고 내용은 500자 이하로 입력해주세요.")
-        String description
+        String description,
+
+        @Positive(message = "신고 대상 회원 ID는 양수여야 합니다.")
+        Long targetMemberId
 ) {
 }

--- a/src/main/java/com/dongsoop/dongsoop/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/report/service/ReportServiceImpl.java
@@ -71,6 +71,11 @@ public class ReportServiceImpl implements ReportService {
     }
 
     private Report buildReport(CreateReportRequest request, Member reporter, String targetUrl) {
+        Member targetMember = null;
+        if (request.targetMemberId() != null) {
+            targetMember = memberRepository.getReferenceById(request.targetMemberId());
+        }
+
         return Report.builder()
                 .reporter(reporter)
                 .reportType(request.reportType())
@@ -78,6 +83,7 @@ public class ReportServiceImpl implements ReportService {
                 .reportReason(request.reason())
                 .description(request.description())
                 .targetUrl(targetUrl)
+                .targetMember(targetMember)
                 .build();
     }
 


### PR DESCRIPTION
- CreateReportRequest에 targetMemberId 필드 추가
- ReportServiceImp.buildReport를 업데이트하여 제공될 때 targetMember를 설정합니다
- 신고 작성 중에 회원 참조 직접 할당 활성화