### PR TITLE
공지사항 파싱 시 헤더 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeLinkParser.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/util/NoticeLinkParser.java
@@ -58,6 +58,7 @@ public class NoticeLinkParser {
         } while (matcher.find());
 
         linkBuilder.append(departmentUrlSuffix);
+        linkBuilder.append(layoutHeader);
 
         return linkBuilder.toString();
     }


### PR DESCRIPTION
대학 홈페이지 구조 조정에 따라 대학 공지에만 추가하였던 레이아웃 헤더를 학과 공지에도 추가하였습니다.