### PR TITLE
모집 게시글 생성 시 태그 유효성 검사 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/validation/annotation/BoardTagValidator.java
@@ -12,8 +12,10 @@ public class BoardTagValidator implements ConstraintValidator<BoardTag, String> 
             return false;
         }
 
-        return tags.trim().isEmpty() || (
-                tags.length() <= RecruitmentValidationConstant.TAG_MAX_LENGTH
-                        && RecruitmentValidationConstant.TAG_PATTERN.matcher(tags).matches());
+        boolean isEmpty = tags.isEmpty();
+        boolean isValidTag = tags.length() <= RecruitmentValidationConstant.TAG_MAX_LENGTH
+                && RecruitmentValidationConstant.TAG_PATTERN.matcher(tags).matches();
+
+        return isEmpty || isValidTag;
     }
 }


### PR DESCRIPTION
모집 게시글 생성 시 태그에 빈값("")을 허용합니다.  
단, null과 공백( )은 허용되지 않습니다.