### PR TITLE
마이페이지 구조 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/mypage/dto/MyRecruitmentOverview.java
+++ b/src/main/java/com/dongsoop/dongsoop/mypage/dto/MyRecruitmentOverview.java
@@ -25,5 +25,5 @@ public interface MyRecruitmentOverview {
 
     LocalDateTime getCreatedAt();
 
-    boolean getIsRecruiting();
+    RecruitmentStatusType getStatus();
 }

--- a/src/main/java/com/dongsoop/dongsoop/mypage/dto/MyRecruitmentOverviewResponse.java
+++ b/src/main/java/com/dongsoop/dongsoop/mypage/dto/MyRecruitmentOverviewResponse.java
@@ -17,7 +17,7 @@ public record MyRecruitmentOverviewResponse(
         List<String> departmentTypeList,
         RecruitmentType boardType,
         LocalDateTime createdAt,
-        boolean isRecruiting
+        RecruitmentStatusType status
 ) {
     public MyRecruitmentOverviewResponse(MyRecruitmentOverview openedRecruitment) {
         this(
@@ -31,7 +31,7 @@ public record MyRecruitmentOverviewResponse(
                 splitDepartmentType(openedRecruitment.getDepartmentTypeList()),
                 openedRecruitment.getBoardType(),
                 openedRecruitment.getCreatedAt(),
-                openedRecruitment.getIsRecruiting()
+                openedRecruitment.getStatus()
         );
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/mypage/dto/RecruitmentStatusType.java
+++ b/src/main/java/com/dongsoop/dongsoop/mypage/dto/RecruitmentStatusType.java
@@ -1,0 +1,8 @@
+package com.dongsoop.dongsoop.mypage.dto;
+
+public enum RecruitmentStatusType {
+
+    RECRUITING,
+    WAITING,
+    ENDED
+}

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/repository/RecruitmentRepository.java
@@ -19,7 +19,7 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
      */
     @Query(value = """
             SELECT
-                id, volunteer, startAt, endAt, title, content, tags, departmentTypeList, boardType, createdAt, isRecruiting
+                id, volunteer, startAt, endAt, title, content, tags, departmentTypeList, boardType, createdAt, status
             FROM (
                 (SELECT
                     p.id AS id,
@@ -34,7 +34,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     STRING_AGG(d.name, ',') AS departmentTypeList,
                     'PROJECT' AS boardType,
                     p.created_At AS createdAt,
-                    (p.end_at > NOW() AND p.start_at < NOW()) AS isRecruiting,
+                    CASE
+                        WHEN p.end_at > NOW() AND p.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN p.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status,
                     pa.apply_time AS applyTime
                 FROM project_board p
                 LEFT JOIN project_apply pa ON p.id = pa.project_board_id
@@ -58,7 +62,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     STRING_AGG(d.name, ',') AS departmentTypeList,
                     'STUDY' AS boardType,
                     s.created_at AS createdAt,
-                    (s.end_at > NOW() AND s.start_at < NOW()) AS isRecruiting,
+                    CASE
+                        WHEN s.end_at > NOW() AND s.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN s.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status,
                     sa.apply_time AS applyTime
                 FROM study_board s
                 LEFT JOIN study_apply sa ON s.id = sa.study_board_id
@@ -82,7 +90,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     d.name AS departmentTypeList,
                     'TUTORING' AS boardType,
                     t.created_at AS createdAt,
-                    (t.end_at > NOW() AND t.start_at < NOW()) AS isRecruiting,
+                    CASE
+                        WHEN t.end_at > NOW() AND t.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN t.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status,
                     ta.apply_time AS applyTime
                 FROM tutoring_board t
                 LEFT JOIN tutoring_apply ta ON t.id = ta.tutoring_board_id
@@ -108,7 +120,7 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
      */
     @Query(value = """
             SELECT
-                id, volunteer, startAt, endAt, title, content, tags, departmentTypeList, boardType, createdAt, isRecruiting
+                id, volunteer, startAt, endAt, title, content, tags, departmentTypeList, boardType, createdAt, status
             FROM (
                 (SELECT
                     p.id AS id,
@@ -123,7 +135,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     STRING_AGG(d.name, ',') AS departmentTypeList,
                     'PROJECT' AS boardType,
                     p.created_At AS createdAt,
-                    (p.end_at > NOW() AND p.start_at < NOW()) AS isRecruiting
+                    CASE
+                        WHEN p.end_at > NOW() AND p.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN p.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status
                 FROM project_board p
                 LEFT JOIN project_board_department pd ON p.id = pd.project_board_id
                 LEFT JOIN department d ON pd.department_id = d.id
@@ -145,7 +161,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     STRING_AGG(d.name, ',') AS departmentTypeList,
                     'STUDY' AS boardType,
                     s.created_at AS createdAt,
-                    (s.end_at > NOW() AND s.start_at < NOW()) AS isRecruiting
+                    CASE
+                        WHEN s.end_at > NOW() AND s.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN s.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status
                 FROM study_board s
                 LEFT JOIN study_board_department sd ON s.id = sd.study_board_id
                 LEFT JOIN department d ON sd.department_id = d.id
@@ -167,7 +187,11 @@ public interface RecruitmentRepository extends JpaRepository<TutoringBoard, Long
                     d.name AS departmentTypeList,
                     'TUTORING' AS boardType,
                     t.created_at AS createdAt,
-                    (t.end_at > NOW() AND t.start_at < NOW()) AS isRecruiting
+                    CASE
+                        WHEN t.end_at > NOW() AND t.start_at <= NOW() THEN 'RECRUITING'
+                        WHEN t.start_at > NOW() THEN 'WAITING'
+                        ELSE 'ENDED'
+                    END AS status
                 FROM tutoring_board t
                 LEFT JOIN department d ON t.department_id = d.id
                 WHERE t.author = :memberId


### PR DESCRIPTION
마이페이지에서 일부 기능이 수정되었습니다.

- 개설한 게시물 목록 조회 시 `isRecruitment(boolean)`필드가 `status(RecruitmentStatusType)`으로 수정되었습니다.
   - 이는 모집중, 모집종료 상태를 넘어 모집 대기 상태를 추가하기 위함입니다.
- 지원한 모집 게시물 목록 조회 시 `MyRecruitmentOverview` 에서 `MyRecruitmentOverviewResponse`로 수정되었습니다.
   - department가 String 타입("학과1,학과2")이 아닌 List로 반환됩니다.