### PR TITLE
그룹채팅방 초대 기능 및 서비스 구조 개선, 중복 코드 제거

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.chat.controller;
 
 import com.dongsoop.dongsoop.chat.dto.CreateGroupRoomRequest;
 import com.dongsoop.dongsoop.chat.dto.CreateRoomRequest;
+import com.dongsoop.dongsoop.chat.dto.InviteUserRequest;
 import com.dongsoop.dongsoop.chat.dto.KickUserRequest;
 import com.dongsoop.dongsoop.chat.dto.ReadStatusUpdateRequest;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
@@ -11,6 +12,7 @@ import com.dongsoop.dongsoop.chat.entity.IncrementalSyncResponse;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -159,6 +161,17 @@ public class ChatController {
                 ));
 
         return ResponseEntity.ok(participants);
+    }
+
+    @PostMapping("/room/{roomId}/invite")
+    public ResponseEntity<ChatMessage> inviteUserToRoom(
+            @PathVariable("roomId") String roomId,
+            @RequestBody @Valid InviteUserRequest request) {
+        Long currentUserId = getCurrentUserId();
+        Long targetUserId = request.targetUserId();
+
+        ChatMessage inviteMessage = chatService.inviteUserToGroupChat(roomId, currentUserId, targetUserId);
+        return ResponseEntity.ok(inviteMessage);
     }
 
     private Long getCurrentUserId() {

--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -9,6 +9,7 @@ import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
 import com.dongsoop.dongsoop.chat.entity.ChatRoomInitResponse;
 import com.dongsoop.dongsoop.chat.entity.IncrementalSyncResponse;
+import com.dongsoop.dongsoop.chat.service.ChatRoomService;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/chat")
 public class ChatController {
     private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
     private final MemberService memberService;
 
     @GetMapping("/room/{roomId}/initialize")
@@ -70,7 +72,8 @@ public class ChatController {
     public ResponseEntity<ChatRoom> createRoom(@RequestBody CreateRoomRequest request) {
         Long currentUserId = getCurrentUserId();
         Long targetUserId = request.getTargetUserId();
-        ChatRoom createdRoom = chatService.createOneToOneChatRoom(currentUserId, targetUserId);
+        String title = request.getTitle();
+        ChatRoom createdRoom = chatRoomService.createOneToOneChatRoom(currentUserId, targetUserId, title);
         return ResponseEntity.ok(createdRoom);
     }
 
@@ -92,7 +95,7 @@ public class ChatController {
     @GetMapping("/room/{roomId}/enter")
     public ResponseEntity<ChatMessage> enterRoom(@PathVariable("roomId") String roomId) {
         Long currentUserId = getCurrentUserId();
-        chatService.enterChatRoom(roomId, currentUserId);
+        chatRoomService.enterChatRoom(roomId, currentUserId);
         ChatMessage enterMessage = chatService.checkFirstTimeEntryAndCreateEnterMessage(roomId, currentUserId);
         return ResponseEntity.ok(enterMessage);
     }
@@ -150,9 +153,9 @@ public class ChatController {
     @GetMapping("/room/{roomId}/participants")
     public ResponseEntity<Map<Long, String>> getRoomParticipants(@PathVariable("roomId") String roomId) {
         Long currentUserId = getCurrentUserId();
-        chatService.enterChatRoom(roomId, currentUserId);
+        chatRoomService.enterChatRoom(roomId, currentUserId);
 
-        ChatRoom room = chatService.getChatRoomById(roomId);
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
 
         Map<Long, String> participants = room.getParticipants().stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateRoomRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateRoomRequest.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateRoomRequest {
     private Long targetUserId;
+    private String title;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/InviteUserRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/InviteUserRequest.java
@@ -1,0 +1,10 @@
+package com.dongsoop.dongsoop.chat.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record InviteUserRequest(
+        @NotNull(message = "초대할 사용자 ID는 필수입니다")
+        @Positive(message = "사용자 ID는 양수여야 합니다")
+        Long targetUserId
+) {}

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
@@ -1,10 +1,17 @@
 package com.dongsoop.dongsoop.chat.entity;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
-
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -34,9 +41,10 @@ public class ChatRoom {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
 
-    public static ChatRoom create(Long user1, Long user2) {
+    public static ChatRoom create(Long user1, Long user2, String title) {
         return ChatRoom.builder()
                 .roomId(generateRandomRoomId())
+                .title(title)
                 .participants(createParticipantSet(user1, user2))
                 .isGroupChat(false)
                 .managerId(null)

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoomEntity.java
@@ -33,6 +33,7 @@ public class ChatRoomEntity {
     @CollectionTable(name = "chat_room_participants",
             joinColumns = @JoinColumn(name = "room_id"))
     @Column(name = "participant_id")
+    @Builder.Default
     private Set<Long> participants = new HashSet<>();
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/dongsoop/dongsoop/chat/exception/GroupChatOnlyException.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/exception/GroupChatOnlyException.java
@@ -1,0 +1,10 @@
+package com.dongsoop.dongsoop.chat.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class GroupChatOnlyException extends CustomException {
+    public GroupChatOnlyException(String action) {
+        super(action + "은(는) 그룹 채팅방에서만 가능합니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/exception/KickedUserInviteException.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/exception/KickedUserInviteException.java
@@ -4,7 +4,7 @@ import com.dongsoop.dongsoop.common.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
 public class KickedUserInviteException extends CustomException {
-  public KickedUserInviteException(Long userId) {
-    super("사용자 " + userId + "는 강퇴된 상태로 초대할 수 없습니다.", HttpStatus.BAD_REQUEST);
-  }
+    public KickedUserInviteException(Long userId) {
+        super("사용자 " + userId + "는 강퇴된 상태로 초대할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/exception/KickedUserInviteException.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/exception/KickedUserInviteException.java
@@ -1,0 +1,10 @@
+package com.dongsoop.dongsoop.chat.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class KickedUserInviteException extends CustomException {
+  public KickedUserInviteException(Long userId) {
+    super("사용자 " + userId + "는 강퇴된 상태로 초대할 수 없습니다.", HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/exception/UserAlreadyInRoomException.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/exception/UserAlreadyInRoomException.java
@@ -1,0 +1,9 @@
+package com.dongsoop.dongsoop.chat.exception;
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class UserAlreadyInRoomException extends CustomException {
+    public UserAlreadyInRoomException(Long userId) {
+        super("사용자 " + userId + "는 이미 채팅방에 참여 중입니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
@@ -43,8 +43,7 @@ public class ChatMessageService {
 
     public ChatMessage findMessageById(List<ChatMessage> messages, String messageId) {
         for (ChatMessage message : messages) {
-            boolean messageFound = message.getMessageId().equals(messageId);
-            if (messageFound) {
+            if (messageId.equals(message.getMessageId())) {
                 return message;
             }
         }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
@@ -19,7 +19,7 @@ public class ChatMessageService {
 
     public ChatMessage processMessage(ChatMessage message) {
         ChatMessage enrichedMessage = chatValidator.validateAndEnrichMessage(message);
-        saveMessage(enrichedMessage);
+        redisChatRepository.saveMessage(message);
         return enrichedMessage;
     }
 
@@ -30,7 +30,7 @@ public class ChatMessageService {
 
     public ChatMessage createAndSaveSystemMessage(String roomId, Long userId, MessageType type) {
         ChatMessage message = buildSystemMessage(roomId, userId, type);
-        saveMessage(message);
+        redisChatRepository.saveMessage(message);
         return message;
     }
 
@@ -74,10 +74,6 @@ public class ChatMessageService {
         return redisChatRepository.findMessagesByRoomIdAfterId(roomId, messageId);
     }
 
-    private void saveMessage(ChatMessage message) {
-        redisChatRepository.saveMessage(message);
-    }
-
     private ChatMessage buildSystemMessage(String roomId, Long userId, MessageType type) {
         return ChatMessage.builder()
                 .messageId(ChatCommonUtils.generateMessageId())
@@ -115,7 +111,7 @@ public class ChatMessageService {
     }
 
     private ChatMessage validateAndSaveOfflineMessage(ChatMessage message) {
-        saveMessage(message);
+        redisChatRepository.saveMessage(message);
         return message;
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatMessageService.java
@@ -1,0 +1,122 @@
+package com.dongsoop.dongsoop.chat.service;
+
+import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+import com.dongsoop.dongsoop.chat.entity.MessageType;
+import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
+import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
+import com.dongsoop.dongsoop.chat.validator.ChatValidator;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+    private final RedisChatRepository redisChatRepository;
+    private final ChatValidator chatValidator;
+
+    public ChatMessage processMessage(ChatMessage message) {
+        ChatMessage enrichedMessage = chatValidator.validateAndEnrichMessage(message);
+        saveMessage(enrichedMessage);
+        return enrichedMessage;
+    }
+
+    public ChatMessage processWebSocketMessage(ChatMessage message, Long userId, String roomId) {
+        ChatMessage enrichedMessage = enrichMessageWithUserData(message, userId, roomId);
+        return processMessage(enrichedMessage);
+    }
+
+    public ChatMessage createAndSaveSystemMessage(String roomId, Long userId, MessageType type) {
+        ChatMessage message = buildSystemMessage(roomId, userId, type);
+        saveMessage(message);
+        return message;
+    }
+
+    public List<ChatMessage> processOfflineMessages(String roomId, Long userId, List<ChatMessage> offlineMessages) {
+        return offlineMessages.stream()
+                .map(message -> processOfflineMessage(message, userId, roomId))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public ChatMessage findMessageById(List<ChatMessage> messages, String messageId) {
+        for (ChatMessage message : messages) {
+            boolean messageFound = message.getMessageId().equals(messageId);
+            if (messageFound) {
+                return message;
+            }
+        }
+        return null;
+    }
+
+    public List<ChatMessage> loadMessagesAfterJoinTime(String roomId, LocalDateTime userJoinTime) {
+        return redisChatRepository.findMessagesByRoomIdAfterTime(roomId, userJoinTime);
+    }
+
+    public List<ChatMessage> loadNewMessages(String roomId, String lastMessageId) {
+        boolean hasLastMessageId = lastMessageId != null;
+        if (hasLastMessageId) {
+            return redisChatRepository.findMessagesByRoomIdAfterId(roomId, lastMessageId);
+        }
+        return redisChatRepository.findMessagesByRoomId(roomId);
+    }
+
+    public int countUnreadMessages(List<ChatMessage> messages, Long userId) {
+        return ChatMessage.countUnreadMessages(messages, userId);
+    }
+
+    public List<ChatMessage> getAllMessages(String roomId) {
+        return redisChatRepository.findMessagesByRoomId(roomId);
+    }
+
+    public List<ChatMessage> getMessagesAfterId(String roomId, String messageId) {
+        return redisChatRepository.findMessagesByRoomIdAfterId(roomId, messageId);
+    }
+
+    private void saveMessage(ChatMessage message) {
+        redisChatRepository.saveMessage(message);
+    }
+
+    private ChatMessage buildSystemMessage(String roomId, Long userId, MessageType type) {
+        return ChatMessage.builder()
+                .messageId(ChatCommonUtils.generateMessageId())
+                .roomId(roomId)
+                .senderId(userId)
+                .content(ChatCommonUtils.createSystemMessageContent(userId))
+                .timestamp(ChatCommonUtils.getCurrentTime())
+                .type(type)
+                .build();
+    }
+
+    private ChatMessage enrichMessageWithUserData(ChatMessage message, Long userId, String roomId) {
+        message.setSenderId(userId);
+        message.setRoomId(roomId);
+        return message;
+    }
+
+    private ChatMessage processOfflineMessage(ChatMessage message, Long userId, String roomId) {
+        boolean messageNull = message == null;
+        if (messageNull) {
+            return null;
+        }
+
+        ChatMessage enrichedMessage = enrichOfflineMessage(message, userId, roomId);
+        return validateAndSaveOfflineMessage(enrichedMessage);
+    }
+
+    private ChatMessage enrichOfflineMessage(ChatMessage message, Long userId, String roomId) {
+        message.setSenderId(userId);
+        message.setRoomId(roomId);
+
+        ChatCommonUtils.enrichMessage(message);
+
+        return message;
+    }
+
+    private ChatMessage validateAndSaveOfflineMessage(ChatMessage message) {
+        saveMessage(message);
+        return message;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatParticipantService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatParticipantService.java
@@ -1,0 +1,155 @@
+package com.dongsoop.dongsoop.chat.service;
+
+import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.entity.MessageType;
+import com.dongsoop.dongsoop.chat.exception.KickedUserInviteException;
+import com.dongsoop.dongsoop.chat.exception.UserAlreadyInRoomException;
+import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
+import com.dongsoop.dongsoop.chat.validator.ChatValidator;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatParticipantService {
+    private final ChatValidator chatValidator;
+    private final ReadStatusService readStatusService;
+
+    public ChatMessage inviteUserToGroupChat(String roomId, Long inviterId, Long targetUserId,
+                                             ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
+
+        validateInviteRequest(room, inviterId, targetUserId);
+        addUserToGroupChatRoom(room, targetUserId, chatRoomService);
+
+        return createInviteSystemMessage(roomId, targetUserId, chatMessageService);
+    }
+
+    public ChatRoom kickUserFromRoom(String roomId, Long managerId, Long userToKick,
+                                     ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
+
+        chatValidator.validateManagerPermission(room, managerId);
+        chatValidator.validateKickableUser(room, userToKick);
+
+        processUserKickWithMessage(room, roomId, userToKick, chatMessageService);
+
+        return chatRoomService.saveRoom(room);
+    }
+
+    public void leaveChatRoom(String roomId, Long userId,
+                              ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
+
+        processUserLeaveWithMessage(room, roomId, userId, chatMessageService);
+        chatRoomService.saveRoom(room);
+        chatRoomService.deleteRoomIfEmpty(room);
+    }
+
+    public ChatMessage checkFirstTimeEntryAndCreateEnterMessage(String roomId, Long userId,
+                                                                ChatRoomService chatRoomService,
+                                                                ChatMessageService chatMessageService) {
+        chatValidator.validateUserForRoom(roomId, userId);
+
+        boolean isFirstTime = isFirstTimeEntry(roomId, userId, chatRoomService, chatMessageService);
+        if (isFirstTime) {
+            return chatMessageService.createAndSaveSystemMessage(roomId, userId, MessageType.ENTER);
+        }
+        return null;
+    }
+
+    public LocalDateTime determineUserJoinTime(ChatRoom room, Long userId, ChatRoomService chatRoomService) {
+        LocalDateTime existingJoinTime = room.getJoinTime(userId);
+
+        boolean hasExistingJoinTime = existingJoinTime != null;
+        if (hasExistingJoinTime) {
+            return existingJoinTime;
+        }
+        return addNewParticipantAndGetJoinTime(room, userId, chatRoomService);
+    }
+
+    private void validateInviteRequest(ChatRoom room, Long inviterId, Long targetUserId) {
+        chatValidator.validateManagerPermission(room, inviterId);
+        validateTargetUserForInvite(room, targetUserId);
+        ChatCommonUtils.validatePositiveUserId(targetUserId);
+    }
+
+    private void validateTargetUserForInvite(ChatRoom room, Long targetUserId) {
+        boolean userAlreadyExists = room.getParticipants().contains(targetUserId);
+        if (userAlreadyExists) {
+            throw new UserAlreadyInRoomException(targetUserId);
+        }
+
+        boolean userWasKicked = room.isKicked(targetUserId);
+        if (userWasKicked) {
+            throw new KickedUserInviteException(targetUserId);
+        }
+    }
+
+    private void addUserToGroupChatRoom(ChatRoom room, Long userId, ChatRoomService chatRoomService) {
+        LocalDateTime joinTime = ChatCommonUtils.getCurrentTime();
+        room.addNewParticipant(userId);
+        chatRoomService.saveRoom(room);
+
+        readStatusService.initializeUserReadStatus(userId, room.getRoomId(), joinTime);
+    }
+
+    private ChatMessage createInviteSystemMessage(String roomId, Long targetUserId,
+                                                  ChatMessageService chatMessageService) {
+        return chatMessageService.createAndSaveSystemMessage(roomId, targetUserId, MessageType.ENTER);
+    }
+
+    private void processUserKickWithMessage(ChatRoom room, String roomId, Long userToKick,
+                                            ChatMessageService chatMessageService) {
+        room.kickUser(userToKick);
+        chatMessageService.createAndSaveSystemMessage(roomId, userToKick, MessageType.LEAVE);
+    }
+
+    private void processUserLeaveWithMessage(ChatRoom room, String roomId, Long userId,
+                                             ChatMessageService chatMessageService) {
+        room.kickUser(userId);
+        chatMessageService.createAndSaveSystemMessage(roomId, userId, MessageType.LEAVE);
+    }
+
+    private boolean isFirstTimeEntry(String roomId, Long userId, ChatRoomService chatRoomService,
+                                     ChatMessageService chatMessageService) {
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
+        LocalDateTime userJoinTime = room.getJoinTime(userId);
+
+        boolean noJoinTime = Objects.isNull(userJoinTime);
+        if (noJoinTime) {
+            return true;
+        }
+        return isNewInvitedUser(roomId, room, userId, userJoinTime, chatMessageService);
+    }
+
+    private boolean isNewInvitedUser(String roomId, ChatRoom room, Long userId, LocalDateTime userJoinTime,
+                                     ChatMessageService chatMessageService) {
+        LocalDateTime roomCreatedAt = room.getCreatedAt();
+        boolean isLaterThanRoomCreation = userJoinTime.isAfter(roomCreatedAt);
+
+        return isLaterThanRoomCreation && hasNotEnteredBefore(roomId, userId, userJoinTime, chatMessageService);
+    }
+
+    private boolean hasNotEnteredBefore(String roomId, Long userId, LocalDateTime joinTime,
+                                        ChatMessageService chatMessageService) {
+        List<ChatMessage> enterMessages = chatMessageService.loadMessagesAfterJoinTime(roomId, joinTime)
+                .stream()
+                .filter(msg -> msg.getType() == MessageType.ENTER)
+                .filter(msg -> msg.getSenderId().equals(userId))
+                .toList();
+
+        return enterMessages.isEmpty();
+    }
+
+    private LocalDateTime addNewParticipantAndGetJoinTime(ChatRoom room, Long userId, ChatRoomService chatRoomService) {
+        LocalDateTime joinTime = ChatCommonUtils.getCurrentTime();
+        room.addNewParticipant(userId);
+        chatRoomService.saveRoom(room);
+        return joinTime;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -1,0 +1,112 @@
+package com.dongsoop.dongsoop.chat.service;
+
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
+import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
+import com.dongsoop.dongsoop.chat.validator.ChatValidator;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final RedisChatRepository redisChatRepository;
+    private final ChatValidator chatValidator;
+    private final ChatSyncService chatSyncService;
+
+    public ChatRoom createOneToOneChatRoom(Long userId, Long targetUserId, String title) {
+        validateOneToOneChatCreation(userId, targetUserId);
+        return findExistingRoomOrCreate(userId, targetUserId, title);
+    }
+
+    public ChatRoom createGroupChatRoom(Long creatorId, Set<Long> participants, String title) {
+        validateGroupChatCreation(participants);
+
+        ChatRoom room = createGroupRoom(participants, creatorId, title);
+        return saveRoom(room);
+    }
+
+    public ChatRoom getChatRoomById(String roomId) {
+        return chatSyncService.findRoomOrRestore(roomId);
+    }
+
+    public List<ChatRoom> getRoomsForUserId(Long userId) {
+        List<ChatRoom> allRooms = redisChatRepository.findRoomsByUserId(userId);
+        return filterNotKickedRooms(allRooms, userId);
+    }
+
+    public void enterChatRoom(String roomId, Long userId) {
+        chatValidator.validateUserForRoom(roomId, userId);
+    }
+
+    public ChatRoom saveRoom(ChatRoom room) {
+        return redisChatRepository.saveRoom(room);
+    }
+
+    public void deleteRoom(String roomId) {
+        redisChatRepository.deleteRoom(roomId);
+    }
+
+    public void updateRoomActivity(String roomId) {
+        ChatRoom room = getChatRoomById(roomId);
+        room.updateActivity();
+        saveRoom(room);
+    }
+
+    public void deleteRoomIfEmpty(ChatRoom room) {
+        boolean roomEmpty = room.getParticipants().isEmpty();
+        if (roomEmpty) {
+            deleteRoom(room.getRoomId());
+        }
+    }
+
+    private void validateOneToOneChatCreation(Long userId, Long targetUserId) {
+        chatValidator.validateSelfChat(userId, targetUserId);
+        ChatCommonUtils.validatePositiveUserId(userId);
+        ChatCommonUtils.validatePositiveUserId(targetUserId);
+    }
+
+    private void validateGroupChatCreation(Set<Long> participants) {
+        boolean participantsEmpty = participants.isEmpty();
+        if (participantsEmpty) {
+            throw new IllegalArgumentException("그룹 채팅 참여자 수가 올바르지 않습니다.");
+        }
+    }
+
+    private ChatRoom findExistingRoomOrCreate(Long userId, Long targetUserId, String title) {
+        ChatRoom existingRoom = redisChatRepository.findRoomByParticipants(userId, targetUserId).orElse(null);
+
+        boolean roomExists = existingRoom != null;
+        if (roomExists) {
+            updateRoomTitleIfNeeded(existingRoom, title);
+            return saveRoom(existingRoom);
+        }
+        return createNewOneToOneRoom(userId, targetUserId, title);
+    }
+
+    private ChatRoom createNewOneToOneRoom(Long userId, Long targetUserId, String title) {
+        ChatRoom room = ChatRoom.create(userId, targetUserId, title);
+        return saveRoom(room);
+    }
+
+    private ChatRoom createGroupRoom(Set<Long> participants, Long creatorId, String title) {
+        return ChatRoom.createWithParticipantsAndTitle(participants, creatorId, title);
+    }
+
+    private List<ChatRoom> filterNotKickedRooms(List<ChatRoom> allRooms, Long userId) {
+        return allRooms.stream()
+                .filter(room -> !room.isKicked(userId))
+                .toList();
+    }
+
+    private void updateRoomTitleIfNeeded(ChatRoom existingRoom, String requestedTitle) {
+        boolean hasRequestedTitle = !ChatCommonUtils.isEmpty(requestedTitle);
+        boolean currentTitleEmpty = ChatCommonUtils.isEmpty(existingRoom.getTitle());
+
+        if (hasRequestedTitle && currentTitleEmpty) {
+            existingRoom.setTitle(requestedTitle);
+        }
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -135,22 +135,19 @@ public class ChatService {
     }
 
     private void processReadTimeUpdate(Long userId, String roomId, LocalDateTime readUntilTime) {
-        boolean hasReadTime = readUntilTime != null;
-        if (hasReadTime) {
+        if (readUntilTime != null) {
             updateReadTimestamp(userId, roomId, readUntilTime);
         }
     }
 
     private void processMessageIdReadUpdate(String roomId, Long userId, String lastReadMessageId) {
-        boolean hasMessageId = lastReadMessageId != null;
-        if (hasMessageId) {
+        if (lastReadMessageId != null) {
             updateReadStatusByMessageId(roomId, userId, lastReadMessageId);
         }
     }
 
     private void processDefaultReadStatus(ReadStatusUpdateRequest request, String roomId, Long userId) {
-        boolean hasNoReadStatusRequest = hasNoReadStatusRequest(request);
-        if (hasNoReadStatusRequest) {
+        if (hasNoReadStatusRequest(request)) {
             updateReadTimestamp(userId, roomId, LocalDateTime.now());
         }
     }
@@ -167,15 +164,13 @@ public class ChatService {
         List<ChatMessage> messages = chatMessageService.getAllMessages(roomId);
 
         ChatMessage targetMessage = chatMessageService.findMessageById(messages, messageId);
-        boolean messageFound = targetMessage != null;
-        if (messageFound) {
+        if (targetMessage != null) {
             updateReadTimestamp(userId, roomId, targetMessage.getTimestamp());
         }
     }
 
     private int calculateUnreadCount(String roomId, Long userId, LocalDateTime lastReadTime) {
-        boolean noLastReadTime = lastReadTime == null;
-        if (noLastReadTime) {
+        if (lastReadTime == null) {
             return 0;
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
@@ -1,0 +1,63 @@
+package com.dongsoop.dongsoop.chat.util;
+
+import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+import com.dongsoop.dongsoop.chat.entity.MessageType;
+import com.dongsoop.dongsoop.chat.exception.UnauthorizedChatAccessException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public final class ChatCommonUtils {
+
+    private ChatCommonUtils() {
+    }
+
+    public static void validatePositiveUserId(Long userId) {
+        boolean invalidId = userId < 0;
+        if (invalidId) {
+            throw new UnauthorizedChatAccessException();
+        }
+    }
+
+    public static String generateMessageId() {
+        return UUID.randomUUID().toString();
+    }
+
+    public static LocalDateTime getCurrentTime() {
+        return LocalDateTime.now();
+    }
+
+    public static String createSystemMessageContent(Long userId) {
+        return userId.toString();
+    }
+
+    public static void enrichMessageId(ChatMessage message) {
+        boolean needsMessageId = message.getMessageId() == null || message.getMessageId().isEmpty();
+        if (needsMessageId) {
+            message.setMessageId(generateMessageId());
+        }
+    }
+
+    public static void enrichMessageTimestamp(ChatMessage message) {
+        boolean needsTimestamp = message.getTimestamp() == null;
+        if (needsTimestamp) {
+            message.setTimestamp(getCurrentTime());
+        }
+    }
+
+    public static void enrichMessageType(ChatMessage message) {
+        boolean needsType = message.getType() == null;
+        if (needsType) {
+            message.setType(MessageType.CHAT);
+        }
+    }
+
+    public static void enrichMessage(ChatMessage message) {
+        enrichMessageId(message);
+        enrichMessageTimestamp(message);
+        enrichMessageType(message);
+    }
+
+    public static boolean isEmpty(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
@@ -33,7 +33,9 @@ public final class ChatCommonUtils {
     }
 
     public static void enrichMessageId(ChatMessage message) {
-        if (message.getMessageId() == null || message.getMessageId().isEmpty()) {
+        String currentMessageId = message.getMessageId();
+
+        if (currentMessageId == null || currentMessageId.isEmpty()) {
             message.setMessageId(generateMessageId());
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
@@ -12,8 +12,10 @@ public final class ChatCommonUtils {
     }
 
     public static void validatePositiveUserId(Long userId) {
-        boolean invalidId = userId < 0;
-        if (invalidId) {
+        if (userId == null) {
+            throw new UnauthorizedChatAccessException();
+        }
+        if (userId < 0) {
             throw new UnauthorizedChatAccessException();
         }
     }
@@ -31,22 +33,19 @@ public final class ChatCommonUtils {
     }
 
     public static void enrichMessageId(ChatMessage message) {
-        boolean needsMessageId = message.getMessageId() == null || message.getMessageId().isEmpty();
-        if (needsMessageId) {
+        if (message.getMessageId() == null || message.getMessageId().isEmpty()) {
             message.setMessageId(generateMessageId());
         }
     }
 
     public static void enrichMessageTimestamp(ChatMessage message) {
-        boolean needsTimestamp = message.getTimestamp() == null;
-        if (needsTimestamp) {
+        if (message.getTimestamp() == null) {
             message.setTimestamp(getCurrentTime());
         }
     }
 
     public static void enrichMessageType(ChatMessage message) {
-        boolean needsType = message.getType() == null;
-        if (needsType) {
+        if (message.getType() == null) {
             message.setType(MessageType.CHAT);
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
@@ -2,7 +2,6 @@ package com.dongsoop.dongsoop.chat.validator;
 
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
-import com.dongsoop.dongsoop.chat.entity.MessageType;
 import com.dongsoop.dongsoop.chat.exception.GroupChatOnlyException;
 import com.dongsoop.dongsoop.chat.exception.InvalidChatRequestException;
 import com.dongsoop.dongsoop.chat.exception.ManagerKickAttemptException;
@@ -12,9 +11,8 @@ import com.dongsoop.dongsoop.chat.exception.UserKickedException;
 import com.dongsoop.dongsoop.chat.exception.UserNotInRoomException;
 import com.dongsoop.dongsoop.chat.repository.ChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatSyncService;
-import java.time.LocalDateTime;
+import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
 import java.util.Objects;
-import java.util.UUID;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -49,7 +47,7 @@ public class ChatValidator {
         validateMessageRequirements(message);
         validateUserForRoom(message.getRoomId(), message.getSenderId());
 
-        enrichMessage(message);
+        ChatCommonUtils.enrichMessage(message);
         return message;
     }
 
@@ -112,30 +110,6 @@ public class ChatValidator {
         }
     }
 
-    private void enrichMessage(ChatMessage message) {
-        enrichMessageId(message);
-        enrichMessageTimestamp(message);
-        enrichMessageType(message);
-    }
-
-    private void enrichMessageId(ChatMessage message) {
-        if (message.getMessageId() == null) {
-            message.setMessageId(generateMessageId());
-        }
-    }
-
-    private void enrichMessageTimestamp(ChatMessage message) {
-        if (message.getTimestamp() == null) {
-            message.setTimestamp(LocalDateTime.now());
-        }
-    }
-
-    private void enrichMessageType(ChatMessage message) {
-        if (message.getType() == null) {
-            message.setType(MessageType.CHAT);
-        }
-    }
-
     private void validateIsGroupChat(ChatRoom room) {
         if (!room.isGroupChat()) {
             throw new GroupChatOnlyException("사용자 초대");
@@ -162,9 +136,5 @@ public class ChatValidator {
         if (Objects.equals(room.getManagerId(), userToKick)) {
             throw new ManagerKickAttemptException();
         }
-    }
-
-    private String generateMessageId() {
-        return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.chat.validator;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
 import com.dongsoop.dongsoop.chat.entity.MessageType;
+import com.dongsoop.dongsoop.chat.exception.GroupChatOnlyException;
 import com.dongsoop.dongsoop.chat.exception.InvalidChatRequestException;
 import com.dongsoop.dongsoop.chat.exception.ManagerKickAttemptException;
 import com.dongsoop.dongsoop.chat.exception.SelfChatException;
@@ -137,7 +138,7 @@ public class ChatValidator {
 
     private void validateIsGroupChat(ChatRoom room) {
         if (!room.isGroupChat()) {
-            throw new IllegalArgumentException("1:1 채팅방에서는 강퇴할 수 없습니다.");
+            throw new GroupChatOnlyException("사용자 초대");
         }
     }
 


### PR DESCRIPTION
#135 

## 작업
채팅 서비스 전반에 공용으로 사용되는 중복된 코드를 제거하고 공통 유틸리티를 통해 관리하였습니다.

## ✨ 새로운 기능

- 1:1 채팅방 제목 설정 기능 추가
- CreateRoomRequest에 title 필드 추가
- ChatRoom.create() 메서드 오버로드로 title 지원
- 기존 API와 완전한 하위 호환성 유지



## 🛠️ 리팩터링

- ChatCommonUtils 유틸리티 클래스 신규 생성

- 사용자 ID 검증, 메시지 생성, 시간 처리 등 공통 기능 통합
- UUID 생성 및 시스템 메시지 내용 생성 중앙화
- 메시지 보강 로직 (ID, 시간, 타입) 표준화
- 이전 ChatService에 있는 로직들을 각 기능에 맞게 Message, Participant, room 서비스로 분리하였습니다.

## 중복 메서드 완전 제거

- validatePositiveUserId(): ChatRoomService, ChatParticipantService에서 중복 제거
- generateMessageId(): ChatValidator, ChatMessageService에서 통합
- 메시지 보강 관련 메서드들: 모든 서비스에서 ChatCommonUtils 사용
