### PR TITLE
모집글 작성 시 자동으로 그룹 채팅방 생성 및 자동 초대 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/board/Board.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/Board.java
@@ -2,20 +2,24 @@ package com.dongsoop.dongsoop.board;
 
 import com.dongsoop.dongsoop.common.BaseEntity;
 import com.dongsoop.dongsoop.member.entity.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.util.Objects;
 
 @MappedSuperclass
 @SuperBuilder
 @NoArgsConstructor
 public abstract class Board extends BaseEntity {
 
+    @Getter
     @NotBlank
     @Column(name = "title", length = 20, nullable = false)
     protected String title;

--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -32,4 +32,8 @@ public abstract class RecruitmentBoard extends Board {
     public void assignChatRoom(String RoomId) {
         this.RoomId = RoomId;
     }
+
+    public boolean hasChatRoom() {
+        return this.RoomId != null;
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -23,4 +24,12 @@ public abstract class RecruitmentBoard extends Board {
 
     @Column(name = "tags", length = RecruitmentValidationConstant.TAG_MAX_LENGTH, nullable = false)
     private String tags;
+
+    @Getter
+    @Column(name = "chat_room_id", length = 50)
+    private String RoomId;
+
+    public void assignChatRoom(String RoomId) {
+        this.RoomId = RoomId;
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/project/service/ProjectApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/project/service/ProjectApplyServiceImpl.java
@@ -123,13 +123,12 @@ public class ProjectApplyServiceImpl implements ProjectApplyService {
         ProjectBoard projectBoard = projectBoardRepository.findById(boardId)
                 .orElseThrow(() -> new ProjectBoardNotFound(boardId));
 
-        String chatRoomId = projectBoard.getRoomId();
-        if (chatRoomId == null) {
+        if (!projectBoard.hasChatRoom()) {
             log.warn("프로젝트 게시판 {}에 채팅방이 연결되지 않음", boardId);
             return;
         }
 
-        chatService.inviteUserToGroupChat(chatRoomId, authorId, applierId);
+        chatService.inviteUserToGroupChat(projectBoard.getRoomId(), authorId, applierId);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/service/StudyApplyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.apply.study.service;
 
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.member.entity.Member;
@@ -25,9 +26,11 @@ import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardDepart
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StudyApplyServiceImpl implements StudyApplyService {
@@ -41,6 +44,8 @@ public class StudyApplyServiceImpl implements StudyApplyService {
     private final StudyBoardDepartmentRepository studyBoardDepartmentRepository;
 
     private final StudyApplyRepositoryCustom studyApplyRepositoryCustom;
+
+    private final ChatService chatService;
 
     public void apply(ApplyStudyBoardRequest request) {
         Member member = memberService.getMemberReferenceByContext();
@@ -108,6 +113,23 @@ public class StudyApplyServiceImpl implements StudyApplyService {
         }
 
         studyApplyRepositoryCustom.updateApplyStatus(request.applierId(), boardId, request.status());
+
+        if (request.compareStatus(RecruitmentApplyStatus.PASS)) {
+            inviteToGroupChat(boardId, request.applierId(), boardOwnerId);
+        }
+    }
+
+    private void inviteToGroupChat(Long boardId, Long applierId, Long authorId) {
+        StudyBoard studyBoard = studyBoardRepository.findById(boardId)
+                .orElseThrow(() -> new StudyBoardNotFound(boardId));
+
+        String chatRoomId = studyBoard.getRoomId();
+        if (chatRoomId == null) {
+            log.warn("게시판 {}에 채팅방이 연결되지 않음", boardId);
+            return;
+        }
+
+        chatService.inviteUserToGroupChat(chatRoomId, authorId, applierId);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/service/StudyApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/service/StudyApplyServiceImpl.java
@@ -123,14 +123,14 @@ public class StudyApplyServiceImpl implements StudyApplyService {
         StudyBoard studyBoard = studyBoardRepository.findById(boardId)
                 .orElseThrow(() -> new StudyBoardNotFound(boardId));
 
-        String chatRoomId = studyBoard.getRoomId();
-        if (chatRoomId == null) {
+        if (!studyBoard.hasChatRoom()) {
             log.warn("게시판 {}에 채팅방이 연결되지 않음", boardId);
             return;
         }
 
-        chatService.inviteUserToGroupChat(chatRoomId, authorId, applierId);
+        chatService.inviteUserToGroupChat(studyBoard.getRoomId(), authorId, applierId);
     }
+
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/service/TutoringApplyServiceImpl.java
@@ -101,13 +101,12 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
         TutoringBoard tutoringBoard = tutoringBoardRepository.findById(boardId)
                 .orElseThrow(() -> new TutoringBoardNotFound(boardId));
 
-        String chatRoomId = tutoringBoard.getRoomId();
-        if (chatRoomId == null) {
+        if (!tutoringBoard.hasChatRoom()) {
             log.warn("튜터링 게시판 {}에 채팅방이 연결되지 않음", boardId);
             return;
         }
 
-        chatService.inviteUserToGroupChat(chatRoomId, authorId, applierId);
+        chatService.inviteUserToGroupChat(tutoringBoard.getRoomId(), authorId, applierId);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/service/TutoringApplyServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/service/TutoringApplyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.recruitment.apply.tutoring.service;
 
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -21,9 +22,11 @@ import com.dongsoop.dongsoop.recruitment.board.tutoring.exception.TutoringBoardN
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TutoringApplyServiceImpl implements TutoringApplyService {
@@ -35,6 +38,8 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
     private final TutoringBoardRepository tutoringBoardRepository;
 
     private final TutoringApplyRepositoryCustom tutoringApplyRepositoryCustom;
+
+    private final ChatService chatService;
 
     public void apply(ApplyTutoringBoardRequest request) {
         Member member = memberService.getMemberReferenceByContext();
@@ -86,6 +91,23 @@ public class TutoringApplyServiceImpl implements TutoringApplyService {
         }
 
         tutoringApplyRepositoryCustom.updateApplyStatus(request.applierId(), boardId, request.status());
+
+        if (request.compareStatus(RecruitmentApplyStatus.PASS)) {
+            inviteToGroupChat(boardId, request.applierId(), boardOwnerId);
+        }
+    }
+
+    private void inviteToGroupChat(Long boardId, Long applierId, Long authorId) {
+        TutoringBoard tutoringBoard = tutoringBoardRepository.findById(boardId)
+                .orElseThrow(() -> new TutoringBoardNotFound(boardId));
+
+        String chatRoomId = tutoringBoard.getRoomId();
+        if (chatRoomId == null) {
+            log.warn("튜터링 게시판 {}에 채팅방이 연결되지 않음", boardId);
+            return;
+        }
+
+        chatService.inviteUserToGroupChat(chatRoomId, authorId, applierId);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
@@ -1,5 +1,7 @@
 package com.dongsoop.dongsoop.recruitment.board.project.service;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.common.exception.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
@@ -18,7 +20,9 @@ import com.dongsoop.dongsoop.recruitment.board.project.exception.ProjectBoardNot
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepositoryCustom;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +44,8 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
 
     private final ProjectApplyRepositoryCustom projectApplyRepositoryCustom;
 
+    private final ChatService chatService;
+
     @Transactional
     public ProjectBoard create(CreateProjectBoardRequest request) {
         ProjectBoard projectBoardToSave = transformToProjectBoard(request);
@@ -55,7 +61,23 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
                 .toList();
 
         projectBoardDepartmentRepository.saveAll(projectBoardDepartmentList);
+
+        createAndLinkChatRoom(projectBoard);
+
         return projectBoard;
+    }
+
+    private void createAndLinkChatRoom(ProjectBoard projectBoard) {
+        Member author = projectBoard.getAuthor();
+        String chatRoomTitle = String.format("[프로젝트] %s", projectBoard.getTitle());
+        
+        Set<Long> initialParticipants = new HashSet<>();
+        initialParticipants.add(author.getId());
+
+        ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
+
+        projectBoard.assignChatRoom(chatRoom.getRoomId());
+        projectBoardRepository.save(projectBoard);
     }
 
     public List<RecruitmentOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType,

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
@@ -20,7 +20,6 @@ import com.dongsoop.dongsoop.recruitment.board.project.exception.ProjectBoardNot
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepositoryCustom;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -70,9 +69,8 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
     private void createAndLinkChatRoom(ProjectBoard projectBoard) {
         Member author = projectBoard.getAuthor();
         String chatRoomTitle = String.format("[프로젝트] %s", projectBoard.getTitle());
-        
-        Set<Long> initialParticipants = new HashSet<>();
-        initialParticipants.add(author.getId());
+
+        Set<Long> initialParticipants = Set.of(author.getId());
 
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
@@ -1,5 +1,7 @@
 package com.dongsoop.dongsoop.recruitment.board.study.service;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.common.exception.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
@@ -18,7 +20,9 @@ import com.dongsoop.dongsoop.recruitment.board.study.exception.StudyBoardNotFoun
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepositoryCustom;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +44,8 @@ public class StudyBoardServiceImpl implements StudyBoardService {
 
     private final StudyApplyRepositoryCustom studyApplyRepositoryCustom;
 
+    private final ChatService chatService;
+
     @Transactional
     public StudyBoard create(CreateStudyBoardRequest request) {
         StudyBoard studyBoardToSave = transformToStudyBoard(request);
@@ -54,7 +60,23 @@ public class StudyBoardServiceImpl implements StudyBoardService {
                 .toList();
 
         studyBoardDepartmentRepository.saveAll(studyBoardDepartmentList);
+
+        createAndLinkChatRoom(studyBoard);
+
         return studyBoard;
+    }
+
+    private void createAndLinkChatRoom(StudyBoard studyBoard) {
+        Member author = studyBoard.getAuthor();
+        String chatRoomTitle = String.format("[스터디] %s", studyBoard.getTitle());
+
+        Set<Long> initialParticipants = new HashSet<>();
+        initialParticipants.add(author.getId());
+
+        ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
+
+        studyBoard.assignChatRoom(chatRoom.getRoomId());
+        studyBoardRepository.save(studyBoard);
     }
 
     public List<RecruitmentOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
@@ -20,7 +20,6 @@ import com.dongsoop.dongsoop.recruitment.board.study.exception.StudyBoardNotFoun
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardDepartmentRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepositoryCustom;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -70,8 +69,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
         Member author = studyBoard.getAuthor();
         String chatRoomTitle = String.format("[스터디] %s", studyBoard.getTitle());
 
-        Set<Long> initialParticipants = new HashSet<>();
-        initialParticipants.add(author.getId());
+        Set<Long> initialParticipants = Set.of(author.getId());
 
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
@@ -17,7 +17,6 @@ import com.dongsoop.dongsoop.recruitment.board.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.exception.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepositoryCustom;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -65,8 +64,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         Member author = tutoringBoard.getAuthor();
         String chatRoomTitle = String.format("[튜터링] %s", tutoringBoard.getTitle());
 
-        Set<Long> initialParticipants = new HashSet<>();
-        initialParticipants.add(author.getId());
+        Set<Long> initialParticipants = Set.of(author.getId());
 
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
@@ -1,5 +1,7 @@
 package com.dongsoop.dongsoop.recruitment.board.tutoring.service;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.common.exception.authentication.NotAuthenticationException;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
@@ -15,10 +17,13 @@ import com.dongsoop.dongsoop.recruitment.board.tutoring.entity.TutoringBoard;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.exception.TutoringBoardNotFound;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepositoryCustom;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +39,8 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
 
     private final MemberService memberService;
 
+    private final ChatService chatService;
+
     public List<RecruitmentOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType,
                                                                      Pageable pageable) {
         return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPageAndDepartmentType(departmentType,
@@ -44,9 +51,27 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         return tutoringBoardRepositoryCustom.findTutoringBoardOverviewsByPage(pageable);
     }
 
+    @Transactional
     public TutoringBoard create(CreateTutoringBoardRequest request) {
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
-        return tutoringBoardRepository.save(tutoringBoard);
+        TutoringBoard savedBoard = tutoringBoardRepository.save(tutoringBoard);
+
+        createAndLinkChatRoom(savedBoard);
+
+        return savedBoard;
+    }
+
+    private void createAndLinkChatRoom(TutoringBoard tutoringBoard) {
+        Member author = tutoringBoard.getAuthor();
+        String chatRoomTitle = String.format("[튜터링] %s", tutoringBoard.getTitle());
+
+        Set<Long> initialParticipants = new HashSet<>();
+        initialParticipants.add(author.getId());
+
+        ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
+
+        tutoringBoard.assignChatRoom(chatRoom.getRoomId());
+        tutoringBoardRepository.save(tutoringBoard);
     }
 
     public RecruitmentDetails getBoardDetailsById(Long boardId) {


### PR DESCRIPTION
## 🎯 기능 요약
- 모집글 작성 시 자동으로 그룹 채팅방이 생성되고, 지원자 합격 시 해당 채팅방에 자동 초대되는 기능을 구현했습니다.

## ✨ 주요 변경사항
### 1. 게시글-채팅방 연동

- RecruitmentBoard에 roomId 필드 추가
- 게시글 생성 시 자동으로 그룹 채팅방 생성
- 생성된 채팅방 ID를 게시글에 저장하여 영구 연결

### 2. 자동 채팅방 생성

- 스터디, 프로젝트, 튜터링 게시글 작성 시 각각 자동으로 채팅방 생성
- 채팅방 제목: [스터디] 게시글제목, [프로젝트] 게시글제목, [튜터링] 게시글제목
- 작성자가 자동으로 채팅방 관리자가 되어 초기 참여

### 3. 합격 시 자동 초대

- 지원자를 합격 처리하면 자동으로 해당 게시글의 채팅방에 초대
- 프론트엔드에서는 기존 합격 API만 호출하면 모든 처리 완료
- 별도의 채팅방 생성/초대 과정 불필요

## 🔧 기술적 구현

- 트랜잭션 기반: 게시글 생성과 채팅방 생성을 하나의 트랜잭션으로 처리
- 에러 핸들링: 채팅방 생성 실패 시 전체 롤백으로 데이터 일관성 보장
- 확장성: 3개 모듈(Study, Project, Tutoring) 모두 동일한 패턴으로 구현

## 🎨 사용자 경험 개선
- 간소화된 UX: 게시글 작성과 동시에 채팅방 자동 생성
- 원클릭 처리: 합격 버튼 한 번으로 상태 변경 + 채팅방 초대 완료
- 일관된 경험: 모든 모집글마다 채팅방이 자동으로 존재