### PR TITLE
모집 게시글 생성 시 DB save 메서드가 두 번 호출되는 문제 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/project/service/ProjectBoardServiceImpl.java
@@ -50,7 +50,7 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
         ProjectBoard projectBoardToSave = transformToProjectBoard(request);
         List<Department> departmentList = getDepartmentReferenceList(request.departmentTypeList());
 
-        ProjectBoard projectBoard = projectBoardRepository.save(projectBoardToSave);
+        ProjectBoard projectBoard = createAndLinkChatRoom(projectBoardToSave);
         List<ProjectBoardDepartment> projectBoardDepartmentList = departmentList.stream()
                 .map(department -> {
                     ProjectBoardDepartmentId projectBoardDepartmentId = new ProjectBoardDepartmentId(projectBoard,
@@ -61,12 +61,10 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
 
         projectBoardDepartmentRepository.saveAll(projectBoardDepartmentList);
 
-        createAndLinkChatRoom(projectBoard);
-
         return projectBoard;
     }
 
-    private void createAndLinkChatRoom(ProjectBoard projectBoard) {
+    private ProjectBoard createAndLinkChatRoom(ProjectBoard projectBoard) {
         Member author = projectBoard.getAuthor();
         String chatRoomTitle = String.format("[프로젝트] %s", projectBoard.getTitle());
 
@@ -75,7 +73,7 @@ public class ProjectBoardServiceImpl implements ProjectBoardService {
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 
         projectBoard.assignChatRoom(chatRoom.getRoomId());
-        projectBoardRepository.save(projectBoard);
+        return projectBoardRepository.save(projectBoard);
     }
 
     public List<RecruitmentOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType,

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/study/service/StudyBoardServiceImpl.java
@@ -50,7 +50,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
         StudyBoard studyBoardToSave = transformToStudyBoard(request);
         List<Department> departmentList = getDepartmentReferenceList(request.departmentTypeList());
 
-        StudyBoard studyBoard = studyBoardRepository.save(studyBoardToSave);
+        StudyBoard studyBoard = createAndLinkChatRoom(studyBoardToSave);
         List<StudyBoardDepartment> studyBoardDepartmentList = departmentList.stream()
                 .map(department -> {
                     StudyBoardDepartmentId studyBoardDepartmentId = new StudyBoardDepartmentId(studyBoard, department);
@@ -60,12 +60,10 @@ public class StudyBoardServiceImpl implements StudyBoardService {
 
         studyBoardDepartmentRepository.saveAll(studyBoardDepartmentList);
 
-        createAndLinkChatRoom(studyBoard);
-
         return studyBoard;
     }
 
-    private void createAndLinkChatRoom(StudyBoard studyBoard) {
+    private StudyBoard createAndLinkChatRoom(StudyBoard studyBoard) {
         Member author = studyBoard.getAuthor();
         String chatRoomTitle = String.format("[스터디] %s", studyBoard.getTitle());
 
@@ -74,7 +72,7 @@ public class StudyBoardServiceImpl implements StudyBoardService {
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 
         studyBoard.assignChatRoom(chatRoom.getRoomId());
-        studyBoardRepository.save(studyBoard);
+        return studyBoardRepository.save(studyBoard);
     }
 
     public List<RecruitmentOverview> getBoardByPageAndDepartmentType(DepartmentType departmentType, Pageable pageable) {

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/board/tutoring/service/TutoringBoardServiceImpl.java
@@ -53,14 +53,10 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
     @Transactional
     public TutoringBoard create(CreateTutoringBoardRequest request) {
         TutoringBoard tutoringBoard = transformToTutoringBoard(request);
-        TutoringBoard savedBoard = tutoringBoardRepository.save(tutoringBoard);
-
-        createAndLinkChatRoom(savedBoard);
-
-        return savedBoard;
+        return createAndLinkChatRoom(tutoringBoard);
     }
 
-    private void createAndLinkChatRoom(TutoringBoard tutoringBoard) {
+    private TutoringBoard createAndLinkChatRoom(TutoringBoard tutoringBoard) {
         Member author = tutoringBoard.getAuthor();
         String chatRoomTitle = String.format("[튜터링] %s", tutoringBoard.getTitle());
 
@@ -69,7 +65,7 @@ public class TutoringBoardServiceImpl implements TutoringBoardService {
         ChatRoom chatRoom = chatService.createGroupChatRoom(author.getId(), initialParticipants, chatRoomTitle);
 
         tutoringBoard.assignChatRoom(chatRoom.getRoomId());
-        tutoringBoardRepository.save(tutoringBoard);
+        return tutoringBoardRepository.save(tutoringBoard);
     }
 
     public RecruitmentDetails getBoardDetailsById(Long boardId) {

--- a/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardCreateTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
@@ -54,6 +56,9 @@ class ProjectBoardCreateTest {
     @Mock
     private ProjectBoardDepartmentRepository projectBoardDepartmentRepository;
 
+    @Mock
+    private ChatService chatService;
+
     private CreateProjectBoardRequest request;
 
     @BeforeEach
@@ -81,6 +86,12 @@ class ProjectBoardCreateTest {
                                 .id(1L)
                                 .build());
 
+        when(chatService.createGroupChatRoom(any(), any(), any()))
+                .thenReturn(
+                        ChatRoom.builder()
+                                .roomId("")
+                                .build());
+
         when(projectBoardRepository.save(any()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -94,13 +105,13 @@ class ProjectBoardCreateTest {
         projectBoardService.create(this.request);
 
         // then
-        ArgumentCaptor<ProjectBoard> captorprojectBoard = ArgumentCaptor.forClass(ProjectBoard.class);
+        ArgumentCaptor<ProjectBoard> captorProjectBoard = ArgumentCaptor.forClass(ProjectBoard.class);
         ArgumentCaptor<List<ProjectBoardDepartment>> captorDepartment = ArgumentCaptor.forClass(List.class);
 
-        verify(projectBoardRepository).save(captorprojectBoard.capture());
+        verify(projectBoardRepository).save(captorProjectBoard.capture());
         verify(projectBoardDepartmentRepository).saveAll(captorDepartment.capture());
 
-        ProjectBoard board = captorprojectBoard.getValue();
+        ProjectBoard board = captorProjectBoard.getValue();
         List<ProjectBoardDepartment> projectBoardDepartmentList = captorDepartment.getValue();
 
         ProjectBoard compareBoard = ProjectBoard.builder()

--- a/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardCreateTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
@@ -53,6 +55,9 @@ class StudyBoardCreateTest {
     @Mock
     private StudyBoardDepartmentRepository studyBoardDepartmentRepository;
 
+    @Mock
+    private ChatService chatService;
+
     private CreateStudyBoardRequest request;
 
     @BeforeEach
@@ -78,6 +83,12 @@ class StudyBoardCreateTest {
                 .thenReturn(
                         Member.builder()
                                 .id(1L)
+                                .build());
+
+        when(chatService.createGroupChatRoom(any(), any(), any()))
+                .thenReturn(
+                        ChatRoom.builder()
+                                .roomId("")
                                 .build());
 
         when(studyBoardRepository.save(any()))

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardCreateTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.dongsoop.dongsoop.chat.entity.ChatRoom;
+import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
@@ -46,6 +48,9 @@ class TutoringBoardCreateTest {
     @Mock
     private DepartmentRepository departmentRepository;
 
+    @Mock
+    private ChatService chatService;
+
     private CreateTutoringBoardRequest request;
 
     @BeforeEach
@@ -67,6 +72,12 @@ class TutoringBoardCreateTest {
                 .thenReturn(
                         Member.builder()
                                 .id(1L)
+                                .build());
+
+        when(chatService.createGroupChatRoom(any(), any(), any()))
+                .thenReturn(
+                        ChatRoom.builder()
+                                .roomId("")
                                 .build());
 
         when(tutoringBoardRepository.save(any()))


### PR DESCRIPTION
모집 게시글 생성 시 request를 entity로 변환한 직후 DB에 저장한 다음,  
게시글에 대한 채팅방 설정 후 게시글 entity를 한 번 더 저장하고 있는 부분에 대해 수정하였습니다.

- 테스트 코드에서 save 메서드를 한 번만 캡처하려 했지만, 두 번 호출되는 문제가 개선되었습니다.