### PR TITLE
디스코드 알림에서 특정 인증 에러만 필터링하는 기능

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/common/config/AuthErrorFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/config/AuthErrorFilter.java
@@ -1,0 +1,20 @@
+package com.dongsoop.dongsoop.common.config;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class AuthErrorFilter extends Filter<ILoggingEvent> {
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        String message = event.getFormattedMessage();
+
+        // "Full authentication is required" 메시지가 포함된 로그는 디스코드에서 제외
+        if (message != null && message.contains("Full authentication is required to access this resource")) {
+            return FilterReply.DENY;
+        }
+
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -23,6 +23,10 @@
     <!-- 디스코드 비동기 처리 설정 (ERROR 레벨 이상만) -->
     <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="DISCORD"/>
+
+        <!-- 커스텀 인증 에러 필터 -->
+        <filter class="com.dongsoop.dongsoop.common.config.AuthErrorFilter"/>
+
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>


### PR DESCRIPTION
## 🔧 변경사항

## AuthErrorFilter.java 추가

- Full authentication is required to access this resource 메시지를 필터링하는 커스텀 필터
- logback Filter 클래스를 상속받아 구현


## logback.xml 설정 변경

- ASYNC_DISCORD appender에 AuthErrorFilter 적용
- 인증 에러만 디스코드 알림에서 제외, 다른 에러는 정상 전송