### PR TITLE
fix: WebSocket 메시지 수신 안되는 문제 및 성능 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
@@ -24,20 +24,23 @@ public class ChatSocketController {
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/message/{roomId}")
-    public void sendMessage(@Payload ChatMessage message,
-                            @DestinationVariable("roomId") String roomId,
-                            Principal principal) {
+    public void sendMessage(
+            @Payload ChatMessage message,
+            @DestinationVariable("roomId") String roomId,
+            Principal principal) {
 
         Long userId = extractUserIdFromPrincipal(principal);
-        BlockStatus status = chatService.getBlockStatus(roomId, userId);
 
+        BlockStatus status = chatService.getBlockStatus(roomId, userId);
         if (status == BlockStatus.I_BLOCKED) {
             return;
         }
 
         ChatMessage processedMessage = chatService.processWebSocketMessage(message, userId, roomId);
 
-        messagingTemplate.convertAndSend("/topic/chat/room/" + roomId, processedMessage);
+        if (processedMessage != null) {
+            messagingTemplate.convertAndSend("/topic/chat/room/" + roomId, processedMessage);
+        }
     }
 
     @MessageMapping("/enter/{roomId}")

--- a/src/main/java/com/dongsoop/dongsoop/common/config/WebSocketConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/config/WebSocketConfig.java
@@ -50,9 +50,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);
         registration.taskExecutor()
-                .corePoolSize(4)
-                .maxPoolSize(10)
-                .queueCapacity(100);
+                .corePoolSize(16)
+                .maxPoolSize(50)
+                .queueCapacity(300);
     }
 
     @Bean


### PR DESCRIPTION
## 🐛 문제
- 그룹 채팅방에 혼자 있을 때 메시지 수신이 안되는 문제
- 1:1 채팅에서 상대방이 오프라인일 때 메시지 수신이 안되는 문제

## 🔧 해결 방법
### 1. WebSocket 메시지 브로드캐스트 방식 변경
- `@SendTo` → `SimpMessagingTemplate` 사용
- 메시지 발신자 본인도 포함하여 브로드캐스트하도록 수정
- 기존 블락 상태 확인 로직은 그대로 유지

### 2. WebSocket 스레드풀 확장
- corePoolSize: 4 → 16
- maxPoolSize: 10 → 50
- queueCapacity: 100 → 300
- 동시 접속자 증가 시 안정성 향상