### PR TITLE
fix: FCM 알림 실패로 인한 메시지 처리 중단 문제 해결

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.chat.controller;
 
+import com.dongsoop.dongsoop.chat.dto.CreateContactRoomRequest;
 import com.dongsoop.dongsoop.chat.dto.CreateGroupRoomRequest;
 import com.dongsoop.dongsoop.chat.dto.CreateRoomRequest;
 import com.dongsoop.dongsoop.chat.dto.InviteUserRequest;
@@ -175,6 +176,21 @@ public class ChatController {
 
         ChatMessage inviteMessage = chatService.inviteUserToGroupChat(roomId, currentUserId, targetUserId);
         return ResponseEntity.ok(inviteMessage);
+    }
+
+    @PostMapping("/room/contact")
+    public ResponseEntity<ChatRoom> createContactRoom(@RequestBody CreateContactRoomRequest request) {
+        Long currentUserId = getCurrentUserId();
+
+        ChatRoom createdRoom = chatRoomService.createContactChatRoom(
+                currentUserId,
+                request.getTargetUserId(),
+                request.getBoardType(),
+                request.getBoardId(),
+                request.getBoardTitle()
+        );
+
+        return ResponseEntity.ok(createdRoom);
     }
 
     private Long getCurrentUserId() {

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
@@ -1,0 +1,15 @@
+package com.dongsoop.dongsoop.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateContactRoomRequest {
+    private Long targetUserId;
+    private String boardType;
+    private Long boardId;
+    private String boardTitle;
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -91,6 +91,15 @@ public class ChatRoomService {
         return saveRoom(room);
     }
 
+    public ChatRoom createContactChatRoom(Long userId, Long targetUserId, String boardType, Long boardId,
+                                          String boardTitle) {
+        String title = String.format("[문의] %s", boardTitle);
+
+        ChatRoom room = createNewOneToOneRoom(userId, targetUserId, title);
+
+        return saveRoom(room);
+    }
+
     private ChatRoom createGroupRoom(Set<Long> participants, Long creatorId, String title) {
         return ChatRoom.createWithParticipantsAndTitle(participants, creatorId, title);
     }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -11,15 +11,14 @@ import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberblock.constant.BlockStatus;
 import com.dongsoop.dongsoop.memberblock.repository.MemberBlockRepository;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -79,11 +78,15 @@ public class ChatService {
     public ChatMessage processWebSocketMessage(ChatMessage message, Long userId, String roomId) {
         ChatMessage processedMessage = chatMessageService.processWebSocketMessage(message, userId, roomId);
         ChatRoom room = chatRoomService.updateRoomActivity(roomId);
-        String senderName = memberService.getNicknameById(userId);
 
         Set<Long> receiver = new HashSet<>(room.getParticipants());
         receiver.remove(userId);
-        notificationService.sendNotificationForChat(receiver, senderName, message.getContent());
+
+        if (!receiver.isEmpty()) {
+            String senderName = memberService.getNicknameById(userId);
+            notificationService.sendNotificationForChat(receiver, senderName, message.getContent());
+        }
+
         return processedMessage;
     }
 


### PR DESCRIPTION
## 혼자 채팅방에 있을시 Fcm 알림 서비스 예외로 인한 브로드캐스트 중단 문제

1. 혼자 있으면 알림 받을 사람이 없음
2. 알림 서비스 호출 자체가 불필요
3. 근본적으로 호출하지 않는 게 맞음

- 혼자 있는 방: receiver.isEmpty() → 알림 전송 안 함 → 메시지만 브로드캐스트
- 상대방 있는 방: !receiver.isEmpty() → 알림 전송 → 메시지 브로드캐스트

채팅방에 혼자 있을 시 알림 전송이 건너 뛰도록 조건을 달아서 해결했습니다.