### PR TITLE
알림 전송 시 데이터 삽입 시점 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -44,14 +44,14 @@ public class FCMServiceImpl implements FCMService {
     @Override
     public ApnsConfig getApnsConfig(String title, String body, NotificationType type, String value) {
         return ApnsConfig.builder()
+                .putCustomData("type", type.toString())
+                .putCustomData("value", value)
                 .setAps(Aps.builder()
                         .setAlert(ApsAlert.builder()
                                 .setTitle(title)
                                 .setBody(body)
                                 .build())
                         .setSound("default")
-                        .putCustomData("type", type.toString())
-                        .putCustomData("value", value)
                         .build())
                 .build();
     }


### PR DESCRIPTION
## 주요 내용

APNS 설정 시 커스텀 데이터를 APS가 아닌 ApnsConfig Builder에 직접 추가하도록 수정했습니다.