### PR TITLE
시간표 학기 기준 전체 삭제 기능 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -55,6 +55,7 @@ public class TimetableController {
     }
 
     @DeleteMapping("/{year}/{semester}")
+    @Secured(RoleType.USER_ROLE)
     public ResponseEntity<List<TimetableView>> deleteTimetableBySemester(@PathVariable("year") Year year,
                                                                          @PathVariable("semester") SemesterType semester) {
         timetableService.deleteTimetable(year, semester);

--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -54,6 +54,15 @@ public class TimetableController {
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/{year}/{semester}")
+    public ResponseEntity<List<TimetableView>> deleteTimetableBySemester(@PathVariable("year") Year year,
+                                                                         @PathVariable("semester") SemesterType semester) {
+        timetableService.deleteTimetable(year, semester);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+
     @PatchMapping
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> updateTimetable(@RequestBody @Valid UpdateTimetableRequest request) {

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
@@ -18,4 +18,6 @@ public interface TimetableRepositoryCustom {
                                                                    SemesterType semester,
                                                                    DayOfWeek week,
                                                                    LocalTime startAt, LocalTime endAt);
+
+    void deleteByMemberIdAndYearAndSemester(Long memberId, Year year, SemesterType semester);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.timetable.entity.SemesterType;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.transaction.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.Year;
@@ -69,6 +70,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
         return Optional.ofNullable(result);
     }
 
+    @Transactional
     public void deleteByMemberIdAndYearAndSemester(Long memberId, Year year, SemesterType semester) {
         queryFactory
                 .update(timetable)

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -68,4 +68,14 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
 
         return Optional.ofNullable(result);
     }
+
+    public void deleteByMemberIdAndYearAndSemester(Long memberId, Year year, SemesterType semester) {
+        queryFactory
+                .update(timetable)
+                .set(timetable.member.isDeleted, true)
+                .where(timetable.member.id.eq(memberId)
+                        .and(timetable.year.eq(year))
+                        .and(timetable.semester.eq(semester)))
+                .execute();
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -74,7 +74,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
     public void deleteByMemberIdAndYearAndSemester(Long memberId, Year year, SemesterType semester) {
         queryFactory
                 .update(timetable)
-                .set(timetable.member.isDeleted, true)
+                .set(timetable.isDeleted, true)
                 .where(timetable.member.id.eq(memberId)
                         .and(timetable.year.eq(year))
                         .and(timetable.semester.eq(semester)))

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
@@ -16,4 +16,6 @@ public interface TimetableService {
     void deleteTimetable(Long timetableId);
 
     void updateTimetable(UpdateTimetableRequest request);
+
+    void deleteTimetable(Year year, SemesterType semester);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableServiceImpl.java
@@ -109,4 +109,10 @@ public class TimetableServiceImpl implements TimetableService {
                     overlapTimetable.endAt());
         });
     }
+
+    public void deleteTimetable(Year year, SemesterType semester) {
+        Long memberId = memberService.getMemberIdByAuthentication();
+
+        timetableRepositoryCustom.deleteByMemberIdAndYearAndSemester(memberId, year, semester);
+    }
 }


### PR DESCRIPTION
## 주요 내용

기존에 각 시간표만 제거할 수 있던 API와 별개로,  
특정 학기를 제거했을 때 해당 학기의 모든 시간표를 제거하는 API를 추가하였습니다.