### PR TITLE
모바일 알림 내 알림 id 데이터 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
@@ -3,8 +3,8 @@ package com.dongsoop.dongsoop.chat.notification;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepositoryCustom;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
+import com.dongsoop.dongsoop.notification.dto.NotificationSend;
 import com.dongsoop.dongsoop.notification.service.FCMService;
-import com.dongsoop.dongsoop.notification.service.NotificationService;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +16,7 @@ public class ChatNotificationImpl implements ChatNotification {
 
     private final MemberDeviceRepositoryCustom memberDeviceRepositoryCustom;
     private final FCMService fcmService;
-    private final NotificationService notificationService;
-
+ 
     public void send(Set<Long> chatroomMemberIdSet, String chatRoomId, String senderName,
                      String message) {
         // 사용자 id를 통해 FCM 토큰을 가져옴
@@ -28,8 +27,9 @@ public class ChatNotificationImpl implements ChatNotification {
                 .map(MemberDeviceDto::deviceToken)
                 .toList();
 
-        fcmService.sendNotification(deviceTokens, senderName, message, NotificationType.CHAT, chatRoomId);
+        NotificationSend notificationSend = new NotificationSend(null, senderName, message, NotificationType.CHAT,
+                chatRoomId);
 
-        notificationService.save(participantsDevice, senderName, message, NotificationType.CHAT, chatRoomId);
+        fcmService.sendNotification(deviceTokens, notificationSend);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.memberdevice.repository;
 
 import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import java.util.List;
 import java.util.Set;
@@ -8,6 +9,8 @@ import java.util.Set;
 public interface MemberDeviceRepositoryCustom {
 
     List<MemberDeviceDto> getAllMemberDevice();
+
+    List<String> getDeviceByMembers(List<Member> memberList);
 
     List<MemberDeviceDto> getMemberDeviceByDepartment(Department department);
 

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.memberdevice.repository;
 
 import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.memberdevice.entity.QMemberDevice;
 import com.querydsl.core.types.Projections;
@@ -23,6 +24,14 @@ public class MemberDeviceRepositoryCustomImpl implements MemberDeviceRepositoryC
         return queryFactory.select(Projections.constructor(MemberDeviceDto.class,
                         memberDevice.member, memberDevice.deviceToken))
                 .from(memberDevice)
+                .fetch();
+    }
+
+    @Override
+    public List<String> getDeviceByMembers(List<Member> memberList) {
+        return queryFactory.select(memberDevice.deviceToken)
+                .from(memberDevice)
+                .where(memberDevice.member.in(memberList))
                 .fetch();
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/dto/NotificationSend.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/dto/NotificationSend.java
@@ -1,0 +1,13 @@
+package com.dongsoop.dongsoop.notification.dto;
+
+import com.dongsoop.dongsoop.notification.constant.NotificationType;
+
+public record NotificationSend(
+
+        Long id,
+        String title,
+        String body,
+        NotificationType type,
+        String value
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/notification/entity/MemberNotification.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/entity/MemberNotification.java
@@ -6,10 +6,12 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
+@Getter
 @SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
@@ -1,15 +1,15 @@
 package com.dongsoop.dongsoop.notification.service;
 
-import com.dongsoop.dongsoop.notification.constant.NotificationType;
+import com.dongsoop.dongsoop.notification.dto.NotificationSend;
 import com.google.firebase.messaging.ApnsConfig;
-import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
 import java.util.List;
 
 public interface FCMService {
 
-    void sendNotification(List<String> fcmTokenList, String title, String body, NotificationType type, String value);
+    void sendNotification(List<String> fcmTokenList, NotificationSend notificationSend);
 
-    ApnsConfig getApnsConfig(String title, String body, NotificationType type, String value);
+    void sendMessages(MulticastMessage message);
 
-    void sendMessages(List<Message> messageList);
+    ApnsConfig getApnsConfig(NotificationSend notificationSend);
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
@@ -1,15 +1,24 @@
 package com.dongsoop.dongsoop.notification.service;
 
+import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
+import com.dongsoop.dongsoop.notification.entity.MemberNotification;
+import com.dongsoop.dongsoop.notification.entity.NotificationDetails;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Pageable;
 
 public interface NotificationService {
 
-    void save(List<MemberDeviceDto> memberDeviceDtoList, String title, String body, NotificationType type,
-              String value);
+    List<MemberNotification> save(List<MemberDeviceDto> memberDeviceDtoList, String title, String body,
+                                  NotificationType type,
+                                  String value);
+
+    void send(Map<NotificationDetails, List<Member>> memberByNotification);
+
+    Map<NotificationDetails, List<Member>> listToMap(List<MemberNotification> memberNotificationList);
 
     List<NotificationOverview> getNotifications(Pageable pageable);
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -1,16 +1,25 @@
 package com.dongsoop.dongsoop.notification.service;
 
+import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
+import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepositoryCustom;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
+import com.dongsoop.dongsoop.notification.dto.NotificationSend;
 import com.dongsoop.dongsoop.notification.entity.MemberNotification;
 import com.dongsoop.dongsoop.notification.entity.NotificationDetails;
 import com.dongsoop.dongsoop.notification.exception.NotificationNotFoundException;
 import com.dongsoop.dongsoop.notification.repository.NotificationDetailsRepository;
 import com.dongsoop.dongsoop.notification.repository.NotificationRepository;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,10 +31,13 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationDetailsRepository notificationDetailsRepository;
     private final MemberService memberService;
+    private final MemberDeviceRepositoryCustom memberDeviceRepositoryCustom;
+    private final FCMService fcmService;
 
     @Override
-    public void save(List<MemberDeviceDto> memberDeviceDtoList, String title, String body, NotificationType type,
-                     String value) {
+    public List<MemberNotification> save(List<MemberDeviceDto> memberDeviceDtoList, String title, String body,
+                                         NotificationType type,
+                                         String value) {
         NotificationDetails details = NotificationDetails.builder()
                 .title(title)
                 .body(body)
@@ -39,7 +51,57 @@ public class NotificationServiceImpl implements NotificationService {
                 .map((memberDevice) -> new MemberNotification(details, memberDevice.member()))
                 .toList();
 
-        notificationRepository.saveAll(memberNotificationList);
+        return notificationRepository.saveAll(memberNotificationList);
+    }
+
+    @Override
+    public Map<NotificationDetails, List<Member>> listToMap(List<MemberNotification> memberNotificationList) {
+        return memberNotificationList.stream().collect(Collectors.groupingBy(
+                notification -> notification.getId().getDetails(),
+                Collectors.mapping(
+                        notification -> notification.getId().getMember(),
+                        Collectors.toList()
+                )));
+    }
+
+    @Override
+    public void send(Map<NotificationDetails, List<Member>> memberByNotification) {
+        memberByNotification.entrySet().stream()
+                .map(this::toMulticastMessage)
+                .forEach(fcmService::sendMessages);
+    }
+
+    /**
+     * MulticastMessage 변환
+     *
+     * @param notificationEntry { 공지 세부: 회원 리스트 } 구조인 Entry
+     * @return MulticastMessage 변환한 메시지
+     */
+    private MulticastMessage toMulticastMessage(Entry<NotificationDetails, List<Member>> notificationEntry) {
+        NotificationDetails details = notificationEntry.getKey();
+        List<Member> memberList = notificationEntry.getValue();
+        List<String> deviceTokens = memberDeviceRepositoryCustom.getDeviceByMembers(memberList);
+
+        // 학과별 공지 알림 전송
+        Long notificationId = details.getId();
+        String title = details.getTitle();
+        String body = details.getBody();
+        String noticeId = details.getValue();
+
+        NotificationSend notificationSend = new NotificationSend(notificationId, title, body,
+                details.getType(), noticeId);
+        ApnsConfig apnsConfig = fcmService.getApnsConfig(notificationSend);
+
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        return MulticastMessage.builder()
+                .addAllTokens(deviceTokens)
+                .setApnsConfig(apnsConfig)
+                .setNotification(notification)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/project/notification/ProjectApplyNotification.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/project/notification/ProjectApplyNotification.java
@@ -2,7 +2,6 @@ package com.dongsoop.dongsoop.recruitment.apply.project.notification;
 
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepositoryCustom;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
-import com.dongsoop.dongsoop.notification.service.FCMService;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
 import com.dongsoop.dongsoop.recruitment.apply.notification.RecruitmentApplyNotification;
 import org.springframework.stereotype.Component;
@@ -11,9 +10,8 @@ import org.springframework.stereotype.Component;
 public class ProjectApplyNotification extends RecruitmentApplyNotification {
 
     public ProjectApplyNotification(MemberDeviceRepositoryCustom memberDeviceRepositoryCustom,
-                                    FCMService fcmService,
                                     NotificationService notificationService) {
-        super(memberDeviceRepositoryCustom, fcmService, notificationService);
+        super(memberDeviceRepositoryCustom, notificationService);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/notification/StudyApplyNotification.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/study/notification/StudyApplyNotification.java
@@ -2,7 +2,6 @@ package com.dongsoop.dongsoop.recruitment.apply.study.notification;
 
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepositoryCustom;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
-import com.dongsoop.dongsoop.notification.service.FCMService;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
 import com.dongsoop.dongsoop.recruitment.apply.notification.RecruitmentApplyNotification;
 import org.springframework.stereotype.Component;
@@ -11,9 +10,8 @@ import org.springframework.stereotype.Component;
 public class StudyApplyNotification extends RecruitmentApplyNotification {
 
     public StudyApplyNotification(MemberDeviceRepositoryCustom memberDeviceRepositoryCustom,
-                                  FCMService fcmService,
                                   NotificationService notificationService) {
-        super(memberDeviceRepositoryCustom, fcmService, notificationService);
+        super(memberDeviceRepositoryCustom, notificationService);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/notification/TutoringApplyNotification.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/tutoring/notification/TutoringApplyNotification.java
@@ -2,7 +2,6 @@ package com.dongsoop.dongsoop.recruitment.apply.tutoring.notification;
 
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepositoryCustom;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
-import com.dongsoop.dongsoop.notification.service.FCMService;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
 import com.dongsoop.dongsoop.recruitment.apply.notification.RecruitmentApplyNotification;
 import org.springframework.stereotype.Component;
@@ -11,9 +10,8 @@ import org.springframework.stereotype.Component;
 public class TutoringApplyNotification extends RecruitmentApplyNotification {
 
     public TutoringApplyNotification(MemberDeviceRepositoryCustom memberDeviceRepositoryCustom,
-                                     FCMService fcmService,
                                      NotificationService notificationService) {
-        super(memberDeviceRepositoryCustom, fcmService, notificationService);
+        super(memberDeviceRepositoryCustom, notificationService);
     }
 
     @Override


### PR DESCRIPTION
## 주요 내용

- [x] 알림 발송 시 알림 읽음 처리를 위해 id 추가
- [x] 공지사항 알림 발송 로직 개선
   - 병렬 처리를 위해 기존 stream 방식에서 parallelStream으로 수정하였습니다.
- [x] 채팅 알림 저장 로직 제거
  - 채팅은 알림 목록에 노출하지 않기 위해 제거하였습니다.