### PR TITLE
다중 시간표 등록 API

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/controller/TimetableController.java
@@ -47,6 +47,26 @@ public class TimetableController {
                 .build();
     }
 
+    @PostMapping("/multiple")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<List<CreateTimetableRequest>> createMultipleTimetable(
+            @RequestBody List<@Valid CreateTimetableRequest> request) {
+        List<CreateTimetableRequest> failedRequest = timetableService.createTimetable(request);
+
+        if (failedRequest.size() == request.size()) {
+            return ResponseEntity.status(409) // 409 Conflict
+                    .build();
+        }
+
+        if (!failedRequest.isEmpty()) {
+            return ResponseEntity.status(207) // 207 Multi-Status
+                    .body(failedRequest);
+        }
+
+        return ResponseEntity.status(201) // 201 Created
+                .build();
+    }
+
     @DeleteMapping("/{timetableId}")
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> deleteTimetable(@PathVariable("timetableId") Long timetableId) {

--- a/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/service/TimetableService.java
@@ -11,6 +11,8 @@ public interface TimetableService {
 
     void createTimetable(CreateTimetableRequest request);
 
+    List<CreateTimetableRequest> createTimetable(List<CreateTimetableRequest> request);
+
     List<TimetableView> getTimetableView(Year year, SemesterType semester);
 
     void deleteTimetable(Long timetableId);


### PR DESCRIPTION
## 주요 내용

시간표 이미지로 등록 기능과 같이 여러 시간표 정보를 한 번에 등록할 수 있는 API입니다.  
AI 사용률을 줄이기 위해 검증에 성공한 시간표만 저장되며, 검증에 실패한 시간표는 저장되지 않습니다.

에러 처리는 다음과 같습니다.

- 전체 저장 실패할 경우 409 - (Conflict)
- 일부만 성공일 경우 207 (Multi Status)
   - 응답 바디에 실패한 요청 데이터가 반환됩니다.
- 전체 성공한 경우 201 (Created)