### PR TITLE
알림 전송 시 유효하지 않은 토큰 제거

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
@@ -4,7 +4,7 @@ import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepository;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
 import com.dongsoop.dongsoop.notification.dto.NotificationSend;
-import com.dongsoop.dongsoop.notification.service.FCMService;
+import com.dongsoop.dongsoop.notification.service.NotificationService;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ public class ChatNotificationImpl implements ChatNotification {
     private final static Long NON_SAVE_NOTIFICATION_ID = -1L;
 
     private final MemberDeviceRepository memberDeviceRepository;
-    private final FCMService fcmService;
+    private final NotificationService notificationService;
 
     public void send(Set<Long> chatroomMemberIdSet, String chatRoomId, String senderName,
                      String message) {
@@ -33,6 +33,6 @@ public class ChatNotificationImpl implements ChatNotification {
                 NotificationType.CHAT,
                 chatRoomId);
 
-        fcmService.sendNotification(deviceTokens, notificationSend);
+        notificationService.send(deviceTokens, notificationSend);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/notification/ChatNotificationImpl.java
@@ -8,6 +8,7 @@ import com.dongsoop.dongsoop.notification.service.NotificationService;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,6 +20,7 @@ public class ChatNotificationImpl implements ChatNotification {
     private final MemberDeviceRepository memberDeviceRepository;
     private final NotificationService notificationService;
 
+    @Async
     public void send(Set<Long> chatroomMemberIdSet, String chatRoomId, String senderName,
                      String message) {
         // 사용자 id를 통해 FCM 토큰을 가져옴

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepository.java
@@ -10,4 +10,6 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
     Optional<MemberDevice> findByMemberIdAndDeviceToken(Long memberId, String deviceToken);
 
     Optional<MemberDevice> findByDeviceToken(String deviceToken);
+
+    void deleteByDeviceToken(String deviceToken);
 }

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
@@ -12,4 +12,6 @@ public interface MemberDeviceService {
     void bindDeviceWithMemberId(Long memberId, String deviceToken);
 
     Map<Long, List<String>> getDeviceByMember(Collection<Long> memberIdList);
+
+    void deleteByToken(String deviceToken);
 }

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
@@ -79,4 +79,10 @@ public class MemberDeviceServiceImpl implements MemberDeviceService {
                 memberDeviceDto -> memberDeviceDto.member().getId(),
                 Collectors.mapping(MemberDeviceDto::deviceToken, Collectors.toList()));
     }
+
+    @Override
+    @Transactional
+    public void deleteByToken(String deviceToken) {
+        memberDeviceRepository.deleteByDeviceToken(deviceToken);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/dto/MulticastMessageWithTokens.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/dto/MulticastMessageWithTokens.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.notification.dto;
+
+import com.google.firebase.messaging.MulticastMessage;
+import java.util.List;
+
+public record MulticastMessageWithTokens(
+
+        List<String> tokens,
+        MulticastMessage messages
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/notification/exception/ResponseSizeUnmatchedToTokenSizeException.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/exception/ResponseSizeUnmatchedToTokenSizeException.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.notification.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ResponseSizeUnmatchedToTokenSizeException extends CustomException {
+
+    public ResponseSizeUnmatchedToTokenSizeException(int responseSize, int tokenSize) {
+        super("알림 응답의 크기가 토큰 목록의 크기와 일치하지 않습니다.\n응답 수: " + responseSize + " 토큰 수: " + tokenSize,
+                HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/notification/exception/ResponseSizeUnmatchedToTokenSizeException.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/exception/ResponseSizeUnmatchedToTokenSizeException.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public class ResponseSizeUnmatchedToTokenSizeException extends CustomException {
 
     public ResponseSizeUnmatchedToTokenSizeException(int responseSize, int tokenSize) {
-        super("알림 응답의 크기가 토큰 목록의 크기와 일치하지 않습니다.\n응답 수: " + responseSize + " 토큰 수: " + tokenSize,
+        super(String.format("알림 응답의 크기가 토큰 목록의 크기와 일치하지 않습니다.%n응답 수: %d, 토큰 수: %d", responseSize, tokenSize),
                 HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
@@ -10,7 +10,7 @@ public interface FCMService {
 
     void sendNotification(List<String> fcmTokenList, NotificationSend notificationSend);
 
-    void sendMessages(MulticastMessage message);
+    void sendMessages(MulticastMessage message, List<String> tokens);
 
     ApnsConfig getApnsConfig(NotificationSend notificationSend);
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -101,6 +101,7 @@ public class FCMServiceImpl implements FCMService {
             BatchResponse batchResponse = future.get();
             if (batchResponse.getFailureCount() > 0) {
                 handleFailure(batchResponse, tokens);
+                throw new NotificationSendException();
             }
             log.info("Successfully sent messages: {}", batchResponse.getSuccessCount());
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -36,6 +37,7 @@ public class FCMServiceImpl implements FCMService {
     private final ExecutorService notificationExecutor;
 
     @Override
+    @Transactional
     public void sendNotification(List<String> deviceTokenList, NotificationSend notificationSend) {
         // iOS용 APNs 설정
         ApnsConfig apnsConfig = getApnsConfig(notificationSend);
@@ -90,6 +92,7 @@ public class FCMServiceImpl implements FCMService {
     }
 
     @Override
+    @Transactional
     public void sendMessages(MulticastMessage message, List<String> tokens) {
         ApiFuture<BatchResponse> future = firebaseMessaging.sendEachForMulticastAsync(message);
         future.addListener(() -> listener(future, tokens), notificationExecutor);

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.notification.service;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.notification.dto.NotificationSend;
 import com.dongsoop.dongsoop.notification.exception.NotificationSendException;
+import com.dongsoop.dongsoop.notification.exception.ResponseSizeUnmatchedToTokenSizeException;
 import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
@@ -131,7 +132,7 @@ public class FCMServiceImpl implements FCMService {
         if (tokens.size() != responses.size()) {
             log.warn("Token list size does not match response size: tokens={}, responses={}",
                     tokens.size(), responses.size());
-            return;
+            throw new ResponseSizeUnmatchedToTokenSizeException(responses.size(), tokens.size());
         }
 
         for (int i = 0; i < responses.size(); i++) {

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -131,6 +131,11 @@ public class FCMServiceImpl implements FCMService {
 
     private void handleFailure(BatchResponse batchResponse, List<String> tokens) {
         List<SendResponse> responses = batchResponse.getResponses();
+        if (tokens.size() != responses.size()) {
+            log.warn("Token list size does not match response size: tokens={}, responses={}",
+                    tokens.size(), responses.size());
+            return;
+        }
 
         for (int i = 0; i < responses.size(); i++) {
             SendResponse response = responses.get(i);

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -147,18 +147,20 @@ public class FCMServiceImpl implements FCMService {
                 continue;
             }
 
-            // 무효한 토큰 확인
-            if (isInvalidToken(exception)) {
-                String invalidToken = tokens.get(i); // 토큰 리스트와 매핑
+            // 만료된 토큰 확인
+            if (isValidToken(exception)) {
+                String invalidToken = tokens.get(i);
                 memberDeviceService.deleteByToken(invalidToken);
                 log.warn("Invalid FCM token removed: {}", invalidToken);
-            } else {
-                log.error("Error sending FCM message: {}", exception.getMessage());
+
+                continue;
             }
+
+            log.error("Error sending FCM message: {}", exception.getMessage());
         }
     }
 
-    private boolean isInvalidToken(FirebaseMessagingException exception) {
+    private boolean isValidToken(FirebaseMessagingException exception) {
         MessagingErrorCode messagingErrorCode = exception.getMessagingErrorCode();
         if (messagingErrorCode == null) {
             return false;

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -136,6 +136,9 @@ public class FCMServiceImpl implements FCMService {
             }
 
             FirebaseMessagingException exception = response.getException();
+            if (exception == null) {
+                continue;
+            }
 
             // 무효한 토큰 확인
             if (isInvalidToken(exception)) {
@@ -150,6 +153,10 @@ public class FCMServiceImpl implements FCMService {
 
     private boolean isInvalidToken(FirebaseMessagingException exception) {
         MessagingErrorCode messagingErrorCode = exception.getMessagingErrorCode();
+        if (messagingErrorCode == null) {
+            return false;
+        }
+
         boolean isUnregistered = messagingErrorCode.equals(MessagingErrorCode.UNREGISTERED);
         boolean isInvalidArgument = messagingErrorCode.equals(MessagingErrorCode.INVALID_ARGUMENT);
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.notification.service;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
+import com.dongsoop.dongsoop.notification.dto.NotificationSend;
 import com.dongsoop.dongsoop.notification.entity.MemberNotification;
 import com.dongsoop.dongsoop.notification.entity.NotificationDetails;
 import java.util.List;
@@ -14,6 +15,8 @@ public interface NotificationService {
     List<MemberNotification> save(List<MemberDeviceDto> memberDeviceDtoList, String title, String body,
                                   NotificationType type,
                                   String value);
+    
+    void send(List<String> deviceTokenList, NotificationSend notificationSend);
 
     void send(List<MemberNotification> memberNotificationList);
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,12 +68,19 @@ public class NotificationServiceImpl implements NotificationService {
                 )));
     }
 
+    @Override
+    @Async
+    public void send(List<String> deviceTokenList, NotificationSend notificationSend) {
+        fcmService.sendNotification(deviceTokenList, notificationSend);
+    }
+
     /**
      * 알림 전송
      *
      * @param memberNotificationList 저장된 알림 리스트
      */
     @Override
+    @Async
     @Transactional(readOnly = true)
     public void send(List<MemberNotification> memberNotificationList) {
         // 알림을 보낼 대상 회원들

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberdevice.dto.MemberDeviceDto;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.notification.constant.NotificationType;
+import com.dongsoop.dongsoop.notification.dto.MulticastMessageWithTokens;
 import com.dongsoop.dongsoop.notification.dto.NotificationList;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
 import com.dongsoop.dongsoop.notification.dto.NotificationSend;
@@ -104,7 +105,7 @@ public class NotificationServiceImpl implements NotificationService {
         memberByNotification.entrySet().stream()
                 .flatMap((map) ->
                         toMulticastMessage(map.getKey(), map.getValue(), memberIdDevices, unreadCountByMember))
-                .forEach(fcmService::sendMessages);
+                .forEach(message -> fcmService.sendMessages(message.messages(), message.tokens()));
     }
 
     /**
@@ -114,9 +115,9 @@ public class NotificationServiceImpl implements NotificationService {
      * @param memberIdList 공지 대상 회원 ID 리스트
      * @return MulticastMessage 변환한 메시지
      */
-    private Stream<MulticastMessage> toMulticastMessage(NotificationDetails details, List<Long> memberIdList,
-                                                        Map<Long, List<String>> memberIdDevices,
-                                                        Map<Long, Long> unreadCountByMember) {
+    private Stream<MulticastMessageWithTokens> toMulticastMessage(NotificationDetails details, List<Long> memberIdList,
+                                                                  Map<Long, List<String>> memberIdDevices,
+                                                                  Map<Long, Long> unreadCountByMember) {
         // 공지별 회원 알림 전송
         Long notificationId = details.getId();
         String title = details.getTitle();
@@ -164,9 +165,11 @@ public class NotificationServiceImpl implements NotificationService {
      * @param apnsConfigBuilder APNS 설정 빌더
      * @return MulticastMessage 생성한 메시지
      */
-    private MulticastMessage generateMulticastMessage(Long memberId, String title, String body,
-                                                      Map<Long, List<String>> deviceByMember, Notification notification,
-                                                      long unreadCount, ApnsConfig.Builder apnsConfigBuilder) {
+    private MulticastMessageWithTokens generateMulticastMessage(Long memberId, String title, String body,
+                                                                Map<Long, List<String>> deviceByMember,
+                                                                Notification notification,
+                                                                long unreadCount,
+                                                                ApnsConfig.Builder apnsConfigBuilder) {
         // APNS 생성
         Aps aps = fcmService.getAps(title, body, (int) unreadCount);
         ApnsConfig apnsConfig = apnsConfigBuilder.setAps(aps)
@@ -174,12 +177,13 @@ public class NotificationServiceImpl implements NotificationService {
 
         // 회원 디바이스 목록 가져오기
         List<String> deviceList = deviceByMember.get(memberId);
-
-        return MulticastMessage.builder()
+        MulticastMessage messages = MulticastMessage.builder()
                 .addAllTokens(deviceList)
                 .setApnsConfig(apnsConfig)
                 .setNotification(notification)
                 .build();
+
+        return new MulticastMessageWithTokens(deviceList, messages);
     }
 
     @Override

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,7 +69,6 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    @Async
     public void send(List<String> deviceTokenList, NotificationSend notificationSend) {
         fcmService.sendNotification(deviceTokenList, notificationSend);
     }
@@ -81,7 +79,6 @@ public class NotificationServiceImpl implements NotificationService {
      * @param memberNotificationList 저장된 알림 리스트
      */
     @Override
-    @Async
     @Transactional(readOnly = true)
     public void send(List<MemberNotification> memberNotificationList) {
         // 알림을 보낼 대상 회원들

--- a/src/main/java/com/dongsoop/dongsoop/recruitment/apply/notification/RecruitmentApplyNotification.java
+++ b/src/main/java/com/dongsoop/dongsoop/recruitment/apply/notification/RecruitmentApplyNotification.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.notification.constant.NotificationType;
 import com.dongsoop.dongsoop.notification.entity.MemberNotification;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
 import java.util.List;
+import org.springframework.scheduling.annotation.Async;
 
 public abstract class RecruitmentApplyNotification {
 
@@ -24,6 +25,7 @@ public abstract class RecruitmentApplyNotification {
 
     protected abstract NotificationType getOutcomeNotificationType();
 
+    @Async
     public void sendApplyNotification(Long boardId, String boardTitle, Long ownerId) {
         List<MemberDeviceDto> ownerDevice = memberDeviceRepository.getMemberDeviceTokenByMemberId(
                 ownerId);
@@ -43,6 +45,7 @@ public abstract class RecruitmentApplyNotification {
         notificationService.send(memberNotificationList);
     }
 
+    @Async
     public void sendOutcomeNotification(Long boardId, String boardTitle, Long applierId) {
         List<MemberDeviceDto> applierDevice = memberDeviceRepository.getMemberDeviceTokenByMemberId(
                 applierId);


### PR DESCRIPTION
## 주요 내용

- 알림 전송 시 `UNREGISTERED`, `INVALID_ARGUMENT` 와 같이 토큰이 유효하지 않은 경우 토큰 제거
- 알림 로직 비동기 처리
   - 요청 처리 시 알림 성공 여부과 관계없이 정상 응답처리