### PR TITLE
알림 확인 시 뱃지 업데이트

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface MemberDeviceRepositoryCustom {
     List<MemberDeviceDto> getMemberDeviceTokenByMemberIds(Collection<Long> memberIds);
 
     List<MemberDeviceDto> getMemberDeviceTokenByMemberId(Long memberId);
+
+    List<String> getDeviceByMemberId(Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/repository/MemberDeviceRepositoryCustomImpl.java
@@ -52,4 +52,12 @@ public class MemberDeviceRepositoryCustomImpl implements MemberDeviceRepositoryC
                 .where(memberDevice.member.id.eq(memberId))
                 .fetch();
     }
+
+    @Override
+    public List<String> getDeviceByMemberId(Long memberId) {
+        return queryFactory.select(memberDevice.deviceToken)
+                .from(memberDevice)
+                .where(memberDevice.member.id.eq(memberId))
+                .fetch();
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
@@ -11,6 +11,8 @@ public interface MemberDeviceService {
 
     void bindDeviceWithMemberId(Long memberId, String deviceToken);
 
+    List<String> getDeviceByMemberId(Long memberId);
+
     Map<Long, List<String>> getDeviceByMember(Collection<Long> memberIdList);
 
     void deleteByToken(String deviceToken);

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
@@ -56,6 +56,17 @@ public class MemberDeviceServiceImpl implements MemberDeviceService {
     }
 
     /**
+     * MemberId로 MemberDevice 조회
+     *
+     * @param memberId MemberId List
+     * @return MemberId를 key로, deviceToken List를 value로 갖는 Map
+     */
+    @Override
+    public List<String> getDeviceByMemberId(Long memberId) {
+        return memberDeviceRepository.getDeviceByMemberId(memberId);
+    }
+
+    /**
      * MemberId List로 MemberDevice 조회
      *
      * @param memberIdList MemberId List

--- a/src/main/java/com/dongsoop/dongsoop/notice/notification/NoticeNotificationImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/notification/NoticeNotificationImpl.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -21,9 +20,6 @@ public class NoticeNotificationImpl implements NoticeNotification {
 
     private final MemberDeviceRepository memberDeviceRepository;
     private final NotificationService notificationService;
-
-    @Value("${university.domain}")
-    private String universityDomain;
 
     /**
      * 공지사항 알림 전송
@@ -68,7 +64,7 @@ public class NoticeNotificationImpl implements NoticeNotification {
         String body = notice.getNoticeDetails().getTitle();
         List<MemberDeviceDto> deviceTokens = getMemberDeviceDtoByDepartment(department);
 
-        String noticeLink = universityDomain + notice.getNoticeDetails().getLink();
+        String noticeLink = notice.getNoticeDetails().getLink();
         return notificationService.save(deviceTokens, title, body, NotificationType.NOTICE, noticeLink);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
@@ -15,4 +15,6 @@ public interface FCMService {
     ApnsConfig getApnsConfig(NotificationSend notificationSend);
 
     Aps getAps(String title, String body, int badge);
+
+    void updateNotificationBadge(List<String> deviceTokens, int badge);
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -171,4 +171,19 @@ public class FCMServiceImpl implements FCMService {
 
         return isUnregistered || isInvalidArgument;
     }
+
+    public void updateNotificationBadge(List<String> deviceTokens, int badge) {
+        ApnsConfig apnsConfig = ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setBadge(badge)
+                        .build())
+                .build();
+
+        MulticastMessage messages = MulticastMessage.builder()
+                .addAllTokens(deviceTokens)
+                .setApnsConfig(apnsConfig)
+                .build();
+
+        sendMessages(messages, deviceTokens);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -58,7 +58,6 @@ public class FCMServiceImpl implements FCMService {
                                 .setBody(notificationSend.body())
                                 .build())
                         .setSound("default")
-                        .setBadge(1)
                         .build())
                 .build();
     }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -214,5 +214,10 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(NotificationNotFoundException::new);
 
         memberNotification.read();
+
+        Long unreadCountByMemberId = notificationRepository.findUnreadCountByMemberId(requesterId);
+        List<String> devices = memberDeviceService.getDeviceByMemberId(requesterId);
+
+        fcmService.updateNotificationBadge(devices, unreadCountByMemberId.intValue());
     }
 }


### PR DESCRIPTION
## 주요 내용

- [x] 알림을 읽었을 때 앱 뱃지 업데이트용 알림을 발송하여 뱃지를 업데이트합니다.
- [x] 채팅 알림 시 뱃지가 1로 초기화되는 문제를 해결했습니다.