### PR TITLE
익명 사용자 토픽 구독

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/jwt/handler/JwtLogoutHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/handler/JwtLogoutHandler.java
@@ -6,9 +6,11 @@ import com.dongsoop.dongsoop.jwt.exception.TokenNotFoundException;
 import com.dongsoop.dongsoop.memberdevice.entity.MemberDevice;
 import com.dongsoop.dongsoop.memberdevice.exception.UnregisteredDeviceException;
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepository;
+import com.dongsoop.dongsoop.notification.service.FCMService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -26,6 +28,7 @@ public class JwtLogoutHandler implements LogoutHandler {
 
     private final MemberDeviceRepository memberDeviceRepository;
     private final JwtUtil jwtUtil;
+    private final FCMService fcmService;
 
     @Override
     @Transactional
@@ -44,6 +47,7 @@ public class JwtLogoutHandler implements LogoutHandler {
                 .orElseThrow(UnregisteredDeviceException::new);
 
         device.bindMember(null);
+        fcmService.subscribeTopic(List.of(deviceToken), "anonymous");
     }
 
     private String extractTokenFromHeader(HttpServletRequest request) throws TokenNotFoundException {

--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -13,8 +13,11 @@ import com.dongsoop.dongsoop.member.dto.UpdatePasswordRequest;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.member.validate.MemberDuplicationValidator;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
+import com.dongsoop.dongsoop.notification.service.FCMService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,6 +37,10 @@ public class MemberController {
     private final PasswordUpdateMailValidator passwordUpdateMailValidator;
     private final RegisterMailValidator registerMailValidator;
     private final MemberDeviceService memberDeviceService;
+    private final FCMService fcmService;
+
+    @Value("${notification.topic.anonymous}")
+    private String anonymousTopic;
 
     @PostMapping("/password")
     public ResponseEntity<Void> updatePassword(@RequestBody @Valid UpdatePasswordRequest request) {
@@ -65,6 +72,8 @@ public class MemberController {
         memberDeviceService.bindDeviceWithMemberId(
                 loginDetail.getLoginMemberDetail().getId(),
                 loginRequest.getFcmToken());
+
+        fcmService.unsubscribeTopic(List.of(loginRequest.getFcmToken()), anonymousTopic);
 
         LoginResponse loginResponse = new LoginResponse(loginDetail.getLoginMemberDetail(), accessToken, refreshToken);
         return ResponseEntity.ok(loginResponse);

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/controller/MemberDeviceController.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/controller/MemberDeviceController.java
@@ -2,8 +2,11 @@ package com.dongsoop.dongsoop.memberdevice.controller;
 
 import com.dongsoop.dongsoop.memberdevice.dto.DeviceRegisterRequest;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
+import com.dongsoop.dongsoop.notification.service.FCMService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,10 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberDeviceController {
 
     private final MemberDeviceService memberDeviceService;
+    private final FCMService fcmService;
+
+    @Value("${notification.topic.anonymous}")
+    private String anonymousTopic;
 
     @PostMapping
     public ResponseEntity<Void> registerDevice(@RequestBody @Valid DeviceRegisterRequest request) {
         memberDeviceService.registerDevice(request.deviceToken(), request.type());
+        fcmService.subscribeTopic(List.of(anonymousTopic), anonymousTopic);
 
         return ResponseEntity.noContent()
                 .build();

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
@@ -12,6 +12,8 @@ public interface FCMService {
 
     void subscribeTopic(List<String> token, String topic);
 
+    void unsubscribeTopic(List<String> token, String topic);
+
     void sendNotification(List<String> fcmTokenList, NotificationSend notificationSend, Number badge);
 
     void sendMessages(MulticastMessage message, List<String> tokens);

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMService.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public interface FCMService {
 
+    void subscribeTopic(List<String> token, String topic);
+
     void sendNotification(List<String> fcmTokenList, NotificationSend notificationSend, Number badge);
 
     void sendMessages(MulticastMessage message, List<String> tokens);

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -38,6 +38,16 @@ public class FCMServiceImpl implements FCMService {
     private final ExecutorService notificationExecutor;
 
     @Override
+    public void subscribeTopic(List<String> token, String topic) {
+        try {
+            firebaseMessaging.subscribeToTopic(token, topic);
+        } catch (FirebaseMessagingException e) {
+            log.error("Error subscribing to topic {}: {}", topic, e.getMessage());
+            throw new NotificationSendException(e);
+        }
+    }
+
+    @Override
     public void sendNotification(List<String> deviceTokenList, NotificationSend notificationSend, Number badge) {
         // iOS용 APNs 설정
         ApnsConfig apnsConfig = getApnsConfig(notificationSend, badge);

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -48,6 +48,16 @@ public class FCMServiceImpl implements FCMService {
     }
 
     @Override
+    public void unsubscribeTopic(List<String> token, String topic) {
+        try {
+            firebaseMessaging.unsubscribeFromTopic(token, topic);
+        } catch (FirebaseMessagingException e) {
+            log.error("Error unsubscribing from topic {}: {}", topic, e.getMessage());
+            throw new NotificationSendException(e);
+        }
+    }
+
+    @Override
     public void sendNotification(List<String> deviceTokenList, NotificationSend notificationSend, Number badge) {
         // iOS용 APNs 설정
         ApnsConfig apnsConfig = getApnsConfig(notificationSend, badge);


### PR DESCRIPTION
## 관련 이슈

Close #이슈번호

## 🎯 배경

- 로그인을 하지 않은 사용자에게 전용 알림을 보내기 위해

## 🔍 주요 내용

- [x] 디바이스 등록 시 익명 토픽 구독
- [x] 로그인 시 익명 토픽 구독 해지
- [x] 로그아웃 시 익명 토픽 구독

## ⌛️ 리뷰 소요 시간

5분
