### PR TITLE
특정 회원의 전체 알림 읽음 처리 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
@@ -52,7 +52,6 @@ public class NotificationController {
         Long requesterId = memberService.getMemberIdByAuthentication();
 
         notificationService.readAll(requesterId);
-        notificationService.sendUpdatedBadge(requesterId);
 
         return ResponseEntity.noContent()
                 .build();

--- a/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.notification.controller;
 
+import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
 import com.dongsoop.dongsoop.notification.dto.NotificationReadRequest;
 import com.dongsoop.dongsoop.notification.service.NotificationService;
@@ -22,11 +23,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final MemberService memberService;
 
     @GetMapping
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<NotificationOverview> getNotifications(Pageable pageable) {
-        NotificationOverview notifications = notificationService.getNotifications(pageable);
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        NotificationOverview notifications = notificationService.getNotifications(pageable, requesterId);
 
         return ResponseEntity.ok(notifications);
     }
@@ -34,7 +38,9 @@ public class NotificationController {
     @PostMapping("/read")
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> readNotification(@RequestBody NotificationReadRequest request) {
-        notificationService.read(request.id());
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        notificationService.read(request.id(), requesterId);
 
         return ResponseEntity.noContent()
                 .build();
@@ -43,8 +49,10 @@ public class NotificationController {
     @PostMapping("/read-all")
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> readAllNotification() {
-        notificationService.readAll();
-        notificationService.sendUpdatedBadge();
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        notificationService.readAll(requesterId);
+        notificationService.sendUpdatedBadge(requesterId);
 
         return ResponseEntity.noContent()
                 .build();
@@ -53,7 +61,9 @@ public class NotificationController {
     @DeleteMapping("/{id}")
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> deleteNotifications(@PathVariable("id") Long id) {
-        notificationService.deleteMemberNotification(id);
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        notificationService.deleteMemberNotification(id, requesterId);
 
         return ResponseEntity.noContent()
                 .build();

--- a/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/controller/NotificationController.java
@@ -40,6 +40,16 @@ public class NotificationController {
                 .build();
     }
 
+    @PostMapping("/read-all")
+    @Secured(RoleType.USER_ROLE)
+    public ResponseEntity<Void> readAllNotification() {
+        notificationService.readAll();
+        notificationService.sendUpdatedBadge();
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+
     @DeleteMapping("/{id}")
     @Secured(RoleType.USER_ROLE)
     public ResponseEntity<Void> deleteNotifications(@PathVariable("id") Long id) {

--- a/src/main/java/com/dongsoop/dongsoop/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/repository/NotificationRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface NotificationRepositoryCustom {
     List<NotificationUnread> findUnreadCountByMemberIds(Collection<Long> memberIds);
 
     Optional<MemberNotification> findByMemberIdAndNotificationId(Long memberId, Long notificationId);
+
+    void updateAllAsRead(Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/repository/NotificationRepositoryCustomImpl.java
@@ -86,4 +86,14 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 
         return Optional.ofNullable(result);
     }
+
+    @Override
+    public void updateAllAsRead(Long memberId) {
+        queryFactory.update(memberNotice)
+                .set(memberNotice.isRead, true)
+                .where(memberNotice.id.member.id.eq(memberId)
+                        .and(memberNotice.isRead.eq(false))
+                        .and(memberNotice.id.details.isDeleted.eq(false)))
+                .execute();
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
@@ -12,6 +12,4 @@ public interface NotificationService {
     void read(Long notificationId, Long memberId);
 
     void readAll(Long memberId);
-
-    void sendUpdatedBadge(Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
@@ -5,13 +5,13 @@ import org.springframework.data.domain.Pageable;
 
 public interface NotificationService {
 
-    NotificationOverview getNotifications(Pageable pageable);
+    NotificationOverview getNotifications(Pageable pageable, Long memberId);
 
-    void deleteMemberNotification(Long id);
+    void deleteMemberNotification(Long notificationId, Long memberId);
 
-    void read(Long id);
+    void read(Long notificationId, Long memberId);
 
-    void readAll();
+    void readAll(Long memberId);
 
-    void sendUpdatedBadge();
+    void sendUpdatedBadge(Long memberId);
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationService.java
@@ -4,10 +4,14 @@ import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
 import org.springframework.data.domain.Pageable;
 
 public interface NotificationService {
-    
+
     NotificationOverview getNotifications(Pageable pageable);
 
     void deleteMemberNotification(Long id);
 
     void read(Long id);
+
+    void readAll();
+
+    void sendUpdatedBadge();
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -9,7 +9,6 @@ import com.dongsoop.dongsoop.notification.repository.NotificationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,16 +53,16 @@ public class NotificationServiceImpl implements NotificationService {
         fcmService.updateNotificationBadge(devices, (int) unreadCountByMemberId);
     }
 
+    /**
+     * 요청 회원의 모든 알림 읽음 처리 및 뱃지 상태 업데이트
+     *
+     * @param memberId 요청 회원 ID
+     */
     @Override
     @Transactional
     public void readAll(Long memberId) {
-
         notificationRepository.updateAllAsRead(memberId);
-    }
 
-    @Override
-    @Async
-    public void sendUpdatedBadge(Long memberId) {
         List<String> devices = memberDeviceService.getDeviceByMemberId(memberId);
         fcmService.updateNotificationBadge(devices, 0);
     }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -62,6 +62,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @Transactional
     public void readAll() {
         Long requesterId = memberService.getMemberIdByAuthentication();
 

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.notification.service;
 
-import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.notification.dto.NotificationList;
 import com.dongsoop.dongsoop.notification.dto.NotificationOverview;
@@ -19,27 +18,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private final MemberService memberService;
     private final FCMService fcmService;
     private final MemberDeviceService memberDeviceService;
 
     @Override
-    public NotificationOverview getNotifications(Pageable pageable) {
-        Long requesterId = memberService.getMemberIdByAuthentication();
-
-        long unreadCount = notificationRepository.findUnreadCountByMemberId(requesterId);
-        List<NotificationList> notificationLists = notificationRepository.getMemberNotifications(requesterId,
-                pageable);
+    public NotificationOverview getNotifications(Pageable pageable, Long memberId) {
+        long unreadCount = notificationRepository.findUnreadCountByMemberId(memberId);
+        List<NotificationList> notificationLists = notificationRepository.getMemberNotifications(memberId, pageable);
 
         return new NotificationOverview(notificationLists, unreadCount);
     }
 
     @Override
     @Transactional
-    public void deleteMemberNotification(Long id) {
-        Long requesterId = memberService.getMemberIdByAuthentication();
-
-        MemberNotification memberNotification = notificationRepository.findByMemberIdAndNotificationId(requesterId, id)
+    public void deleteMemberNotification(Long notificationId, Long memberId) {
+        MemberNotification memberNotification = notificationRepository.findByMemberIdAndNotificationId(memberId,
+                        notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
 
         memberNotification.delete();
@@ -47,34 +41,30 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @Transactional
-    public void read(Long id) {
-        Long requesterId = memberService.getMemberIdByAuthentication();
-
-        MemberNotification memberNotification = notificationRepository.findByMemberIdAndNotificationId(requesterId, id)
+    public void read(Long notificationId, Long memberId) {
+        MemberNotification memberNotification = notificationRepository.findByMemberIdAndNotificationId(memberId,
+                        notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
 
         memberNotification.read();
 
-        long unreadCountByMemberId = notificationRepository.findUnreadCountByMemberId(requesterId);
-        List<String> devices = memberDeviceService.getDeviceByMemberId(requesterId);
+        long unreadCountByMemberId = notificationRepository.findUnreadCountByMemberId(memberId);
+        List<String> devices = memberDeviceService.getDeviceByMemberId(memberId);
 
         fcmService.updateNotificationBadge(devices, (int) unreadCountByMemberId);
     }
 
     @Override
     @Transactional
-    public void readAll() {
-        Long requesterId = memberService.getMemberIdByAuthentication();
+    public void readAll(Long memberId) {
 
-        notificationRepository.updateAllAsRead(requesterId);
+        notificationRepository.updateAllAsRead(memberId);
     }
 
     @Override
     @Async
-    public void sendUpdatedBadge() {
-        Long requesterId = memberService.getMemberIdByAuthentication();
-
-        List<String> devices = memberDeviceService.getDeviceByMemberId(requesterId);
+    public void sendUpdatedBadge(Long memberId) {
+        List<String> devices = memberDeviceService.getDeviceByMemberId(memberId);
         fcmService.updateNotificationBadge(devices, 0);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -10,6 +10,7 @@ import com.dongsoop.dongsoop.notification.repository.NotificationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,5 +59,21 @@ public class NotificationServiceImpl implements NotificationService {
         List<String> devices = memberDeviceService.getDeviceByMemberId(requesterId);
 
         fcmService.updateNotificationBadge(devices, (int) unreadCountByMemberId);
+    }
+
+    @Override
+    public void readAll() {
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        notificationRepository.updateAllAsRead(requesterId);
+    }
+
+    @Override
+    @Async
+    public void sendUpdatedBadge() {
+        Long requesterId = memberService.getMemberIdByAuthentication();
+
+        List<String> devices = memberDeviceService.getDeviceByMemberId(requesterId);
+        fcmService.updateNotificationBadge(devices, 0);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationServiceImpl.java
@@ -64,6 +64,7 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.updateAllAsRead(memberId);
 
         List<String> devices = memberDeviceService.getDeviceByMemberId(memberId);
-        fcmService.updateNotificationBadge(devices, 0);
+        long unreadCountByMemberId = notificationRepository.findUnreadCountByMemberId(memberId);
+        fcmService.updateNotificationBadge(devices, (int) unreadCountByMemberId);
     }
 }


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 기획 상 전체 읽음을 눌렀을 때 뱃지를 초기화해야 합니다.

## 🔍 주요 내용

- [x] 요청 회원이 받은 알림 중, 읽지 않은 알림을 읽음 상태로 수정
- [x] 알림 뱃지를 0으로 초기화

## ⌛️ 리뷰 소요 시간

3분
