### PR TITLE
일정 반환 구조 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/calendar/service/ScheduleService.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/service/ScheduleService.java
@@ -4,16 +4,17 @@ import com.dongsoop.dongsoop.calendar.dto.CreateMemberScheduleRequest;
 import com.dongsoop.dongsoop.calendar.dto.MemberScheduleUpdateRequest;
 import com.dongsoop.dongsoop.calendar.dto.ScheduleDetails;
 import com.dongsoop.dongsoop.calendar.entity.MemberSchedule;
+import com.dongsoop.dongsoop.member.entity.Member;
 import java.time.YearMonth;
 import java.util.List;
 
 public interface ScheduleService {
 
-    MemberSchedule createMemberSchedule(CreateMemberScheduleRequest createMemberScheduleRequest);
+    MemberSchedule createMemberSchedule(Member requester, CreateMemberScheduleRequest createMemberScheduleRequest);
 
     List<ScheduleDetails> getMemberSchedule(Long memberId, YearMonth yearMonth);
 
-    void deleteMemberSchedule(Long scheduleId);
+    void deleteMemberSchedule(Long scheduleId, Long requesterId);
 
-    void updateMemberSchedule(Long scheduleId, MemberScheduleUpdateRequest request);
+    void updateMemberSchedule(Long scheduleId, Long requesterId, MemberScheduleUpdateRequest request);
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/service/ScheduleServiceImpl.java
@@ -75,14 +75,13 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
     private LocalDate getEndDate(YearMonth yearMonth) {
-        // 다음달 마지막 첫째 날
-        LocalDate firstDayOfNextMonth = yearMonth.plusMonths(1L)
-                .atEndOfMonth();
+        // 이번달 마지막 날
+        LocalDate firstDayOfNextMonth = yearMonth.atEndOfMonth();
 
         long week = firstDayOfNextMonth.getDayOfWeek().getValue();
 
         // 그 주의 시작일
-        return firstDayOfNextMonth.plusDays(7L - week);
+        return firstDayOfNextMonth.plusDays(7L - (week % 7));
     }
 
     @Override


### PR DESCRIPTION
## 관련 이슈

Close #이슈번호

## 🎯 배경

- 일정 UI에서 지난 달 마지막 주와 다음 달 첫째 주의 일정이 보이지 않는 문제
- 일정이 정렬되지 않은 문제

## 🔍 주요 내용

- [x] 지난 달 마지막주 값 추가
   - [x] 이번 달이 일요일부터 시작하는 경우는 제외 
- [x] 시작일을 기준으로 일정 정렬 

## ⌛️ 리뷰 소요 시간

0분
