### PR TITLE
fix: Error retrieving chat rooms that do not exist for blocked users

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/memberblock/service/MemberBlockServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberblock/service/MemberBlockServiceImpl.java
@@ -1,7 +1,5 @@
 package com.dongsoop.dongsoop.memberblock.service;
 
-import com.dongsoop.dongsoop.chat.entity.ChatRoom;
-import com.dongsoop.dongsoop.chat.exception.ChatRoomNotFoundException;
 import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.member.entity.Member;
@@ -72,11 +70,11 @@ public class MemberBlockServiceImpl implements MemberBlockService {
     }
 
     private void sendBlockWebsocketEvent(Member blocker, Member blockedMember, BlockStatus blockStatus) {
-        ChatRoom room = redisChatRepository.findRoomByParticipants(blocker.getId(), blockedMember.getId())
-                .orElseThrow(ChatRoomNotFoundException::new);
-        String roomId = room.getRoomId();
-
-        chatService.sendBlockStatusToUser(roomId, blocker.getId(), blockStatus);
-        chatService.sendBlockStatusToUser(roomId, blockedMember.getId(), BlockStatus.BLOCKED_BY_OTHER);
+        redisChatRepository.findRoomByParticipants(blocker.getId(), blockedMember.getId())
+                .ifPresent(room -> {
+                    String roomId = room.getRoomId();
+                    chatService.sendBlockStatusToUser(roomId, blocker.getId(), blockStatus);
+                    chatService.sendBlockStatusToUser(roomId, blockedMember.getId(), BlockStatus.BLOCKED_BY_OTHER);
+                });
     }
 }


### PR DESCRIPTION
## 관련 이슈

Close #이슈번호

## 🎯 배경 & 🔍 주요 내용

- sendBlockWebsocketEvent 메서드에서 발생하는 문제는 redisChatRepository.findRoomByParticipants 메서드가 특정 사용자들 간의 채팅방을 찾지 못했을 때 ChatRoomNotFoundException을 던지는 순간 404에러가 발생하는 문제를 채팅방이 없을 경우 예외를 던지지 않고 적절히 처리하도록 수정

## ⌛️ 리뷰 소요 시간

1분
