### PR TITLE
비회원을 위한 홈 API 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/home/controller/HomeController.java
+++ b/src/main/java/com/dongsoop/dongsoop/home/controller/HomeController.java
@@ -4,8 +4,10 @@ import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.home.dto.HomeDto;
 import com.dongsoop.dongsoop.home.service.HomeService;
 import com.dongsoop.dongsoop.member.service.MemberService;
+import com.dongsoop.dongsoop.role.entity.RoleType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,9 +22,17 @@ public class HomeController {
     private final MemberService memberService;
 
     @GetMapping("/{departmentType}")
+    @Secured(RoleType.USER_ROLE)
     public ResponseEntity<HomeDto> getHomeData(@PathVariable("departmentType") DepartmentType departmentType) {
         Long requesterId = memberService.getMemberIdByAuthentication();
         HomeDto home = homeService.getHome(requesterId, departmentType);
+
+        return ResponseEntity.ok(home);
+    }
+
+    @GetMapping
+    public ResponseEntity<HomeDto> getHomeDataForAnonymous() {
+        HomeDto home = homeService.getHome();
 
         return ResponseEntity.ok(home);
     }

--- a/src/main/java/com/dongsoop/dongsoop/home/service/HomeService.java
+++ b/src/main/java/com/dongsoop/dongsoop/home/service/HomeService.java
@@ -6,4 +6,6 @@ import com.dongsoop.dongsoop.home.dto.HomeDto;
 public interface HomeService {
 
     HomeDto getHome(Long memberId, DepartmentType departmentType);
+
+    HomeDto getHome();
 }

--- a/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustom.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface NoticeRepositoryCustom {
 
     List<HomeNotice> searchHomeNotices(DepartmentType departmentType);
+
+    List<HomeNotice> searchHomeNotices();
 }

--- a/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
@@ -49,4 +49,20 @@ public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
                 .then(Expressions.constant(NoticeType.OFFICIAL))
                 .otherwise(Expressions.constant(NoticeType.DEPARTMENT));
     }
+
+    @Override
+    public List<HomeNotice> searchHomeNotices() {
+        return queryFactory.select(Projections.constructor(
+                        HomeNotice.class,
+                        noticeDetails.title,
+                        noticeDetails.link,
+                        getNoticeType(department)))
+                .from(notice)
+                .innerJoin(notice.id.noticeDetails, noticeDetails)
+                .innerJoin(notice.id.department, department)
+                .where(notice.id.department.id.eq(DepartmentType.DEPT_1001)) // 대학 공지만
+                .orderBy(noticeDetails.createdAt.desc())
+                .limit(3)
+                .fetch();
+    }
 }


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 비회원도 학사 정보를 조회할 수 있어야 합니다.

## 🔍 주요 내용

- [x] 기존 /home API에서 시간표 제외
- [x] 기존 공지 가져오는 로직에서 대학의 공지만 가져오기
- [x] 시간표는 사용자의 데이터기 때문에 빈 리스트 반환
- [x] 기존 /home API 권한 명시

## ⌛️ 리뷰 소요 시간

5분
