### PR TITLE
fix(home): move department to NoticeType method to dto

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notice/dto/HomeNotice.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/dto/HomeNotice.java
@@ -1,9 +1,22 @@
 package com.dongsoop.dongsoop.notice.dto;
 
+import com.dongsoop.dongsoop.department.entity.DepartmentType;
+
 public record HomeNotice(
 
         String title,
         String link,
         NoticeType type
 ) {
+    public HomeNotice(String title, String link, DepartmentType departmentType) {
+        this(title, link, getNoticeType(departmentType));
+    }
+
+    private static NoticeType getNoticeType(DepartmentType departmentType) {
+        if (departmentType.isAllDepartment()) {
+            return NoticeType.OFFICIAL;
+        }
+
+        return NoticeType.DEPARTMENT;
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
@@ -4,13 +4,9 @@ import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.entity.QDepartment;
 import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.notice.dto.HomeNotice;
-import com.dongsoop.dongsoop.notice.dto.NoticeType;
 import com.dongsoop.dongsoop.notice.entity.QNotice;
 import com.dongsoop.dongsoop.notice.entity.QNoticeDetails;
-import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +29,7 @@ public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
                         HomeNotice.class,
                         noticeDetails.title,
                         noticeDetails.link,
-                        getNoticeType(department)))
+                        department.id))
                 .from(notice)
                 .innerJoin(notice.id.noticeDetails, noticeDetails)
                 .innerJoin(notice.id.department, department)
@@ -43,20 +39,13 @@ public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
                 .fetch();
     }
 
-    private Expression<NoticeType> getNoticeType(QDepartment department) {
-        return new CaseBuilder()
-                .when(department.id.eq(DepartmentType.DEPT_1001))
-                .then(Expressions.constant(NoticeType.OFFICIAL))
-                .otherwise(Expressions.constant(NoticeType.DEPARTMENT));
-    }
-
     @Override
     public List<HomeNotice> searchHomeNotices() {
         return queryFactory.select(Projections.constructor(
                         HomeNotice.class,
                         noticeDetails.title,
                         noticeDetails.link,
-                        getNoticeType(department)))
+                        department.id))
                 .from(notice)
                 .innerJoin(notice.id.noticeDetails, noticeDetails)
                 .innerJoin(notice.id.department, department)


### PR DESCRIPTION
## 관련 이슈

Closes #205 

## 🎯 배경

- 공지 크롤링 시 학과에 따라 공지 타입을 변환하는 과정에서 문제가 발생하여 500 에러
- Expressions가 enum을 감쌌을 때, ORDINAL 또는 NAME중 어떤 값을 사용해야 할지 모르는 문제

## 🔍 주요 내용

- [x] SQL 파트에서 NoticeType을 반환하지 않고 DepartmentType을 반환하도록 수정
- [x] HomeNotice.class dto에서 해당 DepartmentType 인자를 통해 NoticeType을 반환하도록 수정

## ⌛️ 리뷰 소요 시간

3분
