### PR TITLE
공지사항 모바일 알림 실패 해결

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationSendServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationSendServiceImpl.java
@@ -77,7 +77,7 @@ public class NotificationSendServiceImpl implements NotificationSendService {
         Long notificationId = details.getId();
         String title = details.getTitle();
         String body = details.getBody();
-        NotificationType type = details.getType();
+        String type = details.getType().name();
         String value = details.getValue();
 
         // 알림 객체 생성


### PR DESCRIPTION
## 관련 이슈

Closes #208 

## 🎯 배경

- 공지 사항 알림 실패

## 🔍 주요 내용

- [x] 알림에 사용되는 NotificationType 타입을 String으로 변환하여 MulticastMessage 객체에 저장

## ⌛️ 리뷰 소요 시간

0분
