### PR TITLE
로그아웃 시 사용자 모바일 알림 뱃지 초기화

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/jwt/handler/JwtLogoutHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/jwt/handler/JwtLogoutHandler.java
@@ -52,6 +52,7 @@ public class JwtLogoutHandler implements LogoutHandler {
 
         device.bindMember(null);
         fcmService.subscribeTopic(List.of(deviceToken), anonymousTopic);
+        fcmService.updateNotificationBadge(List.of(deviceToken), 0);
     }
 
     private String extractTokenFromHeader(HttpServletRequest request) throws TokenNotFoundException {


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 로그아웃 후에 알림 목록을 확인할 수 없지만, 알림 뱃지가 남아있는 문제

## 🔍 주요 내용

- [x] 로그아웃 처리 후 알림 뱃지 초기화용 알림 전송 로직 추가

## ⌛️ 리뷰 소요 시간

0분
