### PR TITLE
문의방 중복 생성 및 채팅방 타입 구분 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -1,6 +1,12 @@
 package com.dongsoop.dongsoop.chat.controller;
 
-import com.dongsoop.dongsoop.chat.dto.*;
+import com.dongsoop.dongsoop.chat.dto.ChatRoomListResponse;
+import com.dongsoop.dongsoop.chat.dto.CreateContactRoomRequest;
+import com.dongsoop.dongsoop.chat.dto.CreateGroupRoomRequest;
+import com.dongsoop.dongsoop.chat.dto.CreateRoomRequest;
+import com.dongsoop.dongsoop.chat.dto.InviteUserRequest;
+import com.dongsoop.dongsoop.chat.dto.KickUserRequest;
+import com.dongsoop.dongsoop.chat.dto.ReadStatusUpdateRequest;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
 import com.dongsoop.dongsoop.chat.entity.ChatRoomInitResponse;
@@ -10,13 +16,17 @@ import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -172,6 +182,7 @@ public class ChatController {
                 .unreadCount(unreadCount)
                 .lastActivityAt(room.getLastActivityAt())
                 .isGroupChat(room.isGroupChat())
+                .roomType(room.getRoomType())
                 .build();
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomListResponse.java
@@ -18,4 +18,5 @@ public class ChatRoomListResponse {
     private int unreadCount;
     private LocalDateTime lastActivityAt;
     private boolean isGroupChat;
+    private String roomType;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.chat.dto;
 
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateContactRoomRequest {
     private Long targetUserId;
-    private RecruitmentType boardType;
+    private Object boardType;
     private Long boardId;
     private String boardTitle;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatRoom.java
@@ -158,4 +158,14 @@ public class ChatRoom {
         }
         return kickedUsers;
     }
+
+    public String getRoomType() {
+        if (title != null && title.startsWith("[문의]")) {
+            return "contact";
+        }
+        if (isGroupChat) {
+            return "group";
+        }
+        return "oneToOne";
+    }
 }


### PR DESCRIPTION
## 관련 이슈

open #212 

## 🎯 배경

- 문의방 생성 시 같은 게시글에 대해 중복으로 방이 생성되는 문제 발생
- 채팅방 목록에서 문의방, 그룹방, 일반방 구분이 안되어 사용자 경험 저하
- RecruitmentType과 MarketplaceType 게시판 모두에서 문의 기능 필요

## 🔍 주요 내용

- [x] Redis 매핑을 통한 게시글별 문의방 중복 생성 방지 로직 구현
- [x] 채팅방 목록 응답에 roomType 필드 추가하여 방 타입 구분 가능
- [x] Object 타입 사용으로 RecruitmentType과 MarketplaceType 통합 지원
- [x] 게시판별 검증 로직 분리로 확장성 향상

## ⌛️ 리뷰 소요 시간

15분
