### PR TITLE
홈 데이터 조회 시 부가 옵션 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/home/service/HomeServiceImpl.java
@@ -13,6 +13,7 @@ import com.dongsoop.dongsoop.recruitment.repository.RecruitmentRepository;
 import com.dongsoop.dongsoop.timetable.dto.HomeTimetable;
 import com.dongsoop.dongsoop.timetable.entity.SemesterType;
 import com.dongsoop.dongsoop.timetable.repository.TimetableRepository;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.Collections;
@@ -52,9 +53,10 @@ public class HomeServiceImpl implements HomeService {
         Year year = Year.now();
         int month = today.getMonthValue();
         SemesterType semester = SemesterType.fromMonth(month);
+        DayOfWeek week = today.getDayOfWeek();
 
         CompletableFuture<List<HomeTimetable>> fTimetable = call(
-                () -> timetableRepository.searchHomeTimetable(requesterId, year, semester));
+                () -> timetableRepository.searchHomeTimetable(requesterId, year, semester, week));
         CompletableFuture<List<HomeSchedule>> fMemberSchedules = call(
                 () -> memberScheduleRepository.searchHomeSchedule(requesterId, today));
         CompletableFuture<List<HomeSchedule>> fOfficialSchedules = call(

--- a/src/main/java/com/dongsoop/dongsoop/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/home/service/HomeServiceImpl.java
@@ -60,7 +60,8 @@ public class HomeServiceImpl implements HomeService {
         CompletableFuture<List<HomeSchedule>> fOfficialSchedules = call(
                 () -> officialScheduleRepository.searchHomeSchedule(today));
         CompletableFuture<List<HomeNotice>> fNotices = call(() -> noticeRepository.searchHomeNotices(departmentType));
-        CompletableFuture<List<HomeRecruitment>> fRecruitments = call(recruitmentRepository::searchHomeRecruitment);
+        CompletableFuture<List<HomeRecruitment>> fRecruitments = call(
+                () -> recruitmentRepository.searchHomeRecruitment(departmentType.name()));
 
         // 모든 Future 완료 대기
         CompletableFuture.allOf(

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustom.java
@@ -26,5 +26,5 @@ public interface TimetableRepositoryCustom {
 
     List<TodayTimetable> getTimetableNotificationDtoList(Year year, SemesterType semester, DayOfWeek week);
 
-    List<HomeTimetable> searchHomeTimetable(Long memberId, Year year, SemesterType semester);
+    List<HomeTimetable> searchHomeTimetable(Long memberId, Year year, SemesterType semester, DayOfWeek week);
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -109,7 +109,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
     }
 
     @Override
-    public List<HomeTimetable> searchHomeTimetable(Long memberId, Year year, SemesterType semester) {
+    public List<HomeTimetable> searchHomeTimetable(Long memberId, Year year, SemesterType semester, DayOfWeek week) {
         return queryFactory
                 .selectDistinct(Projections.constructor(
                         HomeTimetable.class,
@@ -120,7 +120,8 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
                 .where(timetable.member.id.eq(memberId)
                         .and(timetable.year.eq(year))
                         .and(timetable.semester.eq(semester))
-                        .and(timetable.isDeleted.isFalse()))
+                        .and(timetable.isDeleted.isFalse())
+                        .and(timetable.week.eq(week)))
                 .orderBy(timetable.startAt.asc(), timetable.endAt.asc())
                 .limit(3)
                 .fetch();


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 지원할 수 없는 학과 범위의 모집글이 노출되는 문제
- 오늘 시간표 외 다른 요일 시간표가 노출되는 문제

## 🔍 주요 내용

- [x] 인기 모집 게시글 조회 시 회원의 경우 본인이 지원 가능한 학과만 조회하도록 수정
- [x] 시간표 조회 시 해당 요일의 데이터만 조회하도록 수정

## ⌛️ 리뷰 소요 시간

0분
