### PR TITLE
시간표 스케줄러 정렬 기준 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/timetable/dto/TodayTimetable.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/dto/TodayTimetable.java
@@ -6,6 +6,7 @@ public record TodayTimetable(
 
         String name,
         LocalTime startAt,
+        LocalTime endAt,
         Long memberId
 ) {
 }

--- a/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/timetable/repository/TimetableRepositoryCustomImpl.java
@@ -95,6 +95,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
                 .selectDistinct(Projections.constructor(TodayTimetable.class,
                         timetable.name,
                         timetable.startAt,
+                        timetable.endAt,
                         member.id))
                 .from(timetable)
                 .innerJoin(timetable.member, member)
@@ -104,7 +105,7 @@ public class TimetableRepositoryCustomImpl implements TimetableRepositoryCustom 
                         .and(timetable.semester.eq(semester))
                         .and(timetable.week.eq(week))
                         .and(timetable.isDeleted.isFalse()))
-                .orderBy(timetable.week.asc(), timetable.startAt.asc())
+                .orderBy(timetable.startAt.asc(), timetable.endAt.asc())
                 .fetch();
     }
 


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 특정 요일에 대한 조회임에도 orderBy 절에 요일이 들어가있는 문제

## 🔍 주요 내용

- [x] 해당 orderBy 절을 제거
- [x] 종료일 orderBy 절 추가

## ⌛️ 리뷰 소요 시간

1분
