### PR TITLE
홈 일정 조회 시 타입 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/HomeSchedule.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/HomeSchedule.java
@@ -8,13 +8,14 @@ public record HomeSchedule(
 
         String title,
         LocalTime startAt,
-        LocalTime endAt
+        LocalTime endAt,
+        ScheduleType type
 ) {
-    public HomeSchedule(String title, LocalDateTime startAt, LocalDateTime endAt) {
-        this(title, startAt.toLocalTime(), endAt.toLocalTime());
+    public HomeSchedule(String title, LocalDateTime startAt, LocalDateTime endAt, ScheduleType type) {
+        this(title, startAt.toLocalTime(), endAt.toLocalTime(), type);
     }
 
-    public HomeSchedule(String title, LocalDate startAt, LocalDate endAt) {
-        this(title, LocalTime.MIN, LocalTime.MAX);
+    public HomeSchedule(String title, LocalDate startAt, LocalDate endAt, ScheduleType type) {
+        this(title, LocalTime.MIN, LocalTime.MAX, type);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/repository/MemberScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/repository/MemberScheduleRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.calendar.repository;
 
 import com.dongsoop.dongsoop.calendar.dto.HomeSchedule;
+import com.dongsoop.dongsoop.calendar.dto.ScheduleType;
 import com.dongsoop.dongsoop.calendar.dto.TodaySchedule;
 import com.dongsoop.dongsoop.calendar.entity.MemberSchedule;
 import com.dongsoop.dongsoop.calendar.entity.QMemberSchedule;
@@ -69,7 +70,8 @@ public class MemberScheduleRepositoryCustomImpl implements MemberScheduleReposit
                         HomeSchedule.class,
                         memberSchedule.title,
                         memberSchedule.startAt,
-                        memberSchedule.endAt))
+                        memberSchedule.endAt,
+                        Expressions.constant(ScheduleType.MEMBER)))
                 .from(memberSchedule)
                 .innerJoin(memberSchedule.member, member)
                 .where(startAtDate.eq(date)

--- a/src/main/java/com/dongsoop/dongsoop/calendar/repository/OfficialScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/repository/OfficialScheduleRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.calendar.repository;
 
 import com.dongsoop.dongsoop.calendar.dto.HomeSchedule;
+import com.dongsoop.dongsoop.calendar.dto.ScheduleType;
 import com.dongsoop.dongsoop.calendar.entity.OfficialSchedule;
 import com.dongsoop.dongsoop.calendar.entity.QOfficialSchedule;
 import com.querydsl.core.types.Projections;
@@ -56,7 +57,8 @@ public class OfficialScheduleRepositoryCustomImpl implements OfficialScheduleRep
                         HomeSchedule.class,
                         officialSchedule.title,
                         officialSchedule.startAt,
-                        officialSchedule.endAt))
+                        officialSchedule.endAt,
+                        Expressions.constant(ScheduleType.OFFICIAL)))
                 .from(officialSchedule)
                 .where(startAtDate.eq(date))
                 .fetch();


### PR DESCRIPTION
## 관련 이슈

-

## 🎯 배경

- 학사 일정의 경우 시간이 아닌 별도 표기를 위해

## 🔍 주요 내용

- [x] 회원 일정 조회 시 일정 타입(상수) 추가
- [x] 학사 일정 조회 시 일정 타입(상수) 추가

## ⌛️ 리뷰 소요 시간

2분
