### PR TITLE
매니저 나가기 제한 기능 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -16,13 +16,16 @@ public abstract class RecruitmentBoard extends Board {
 
     @NotNull
     @Column(name = "start_at", nullable = false)
+    @Getter
     private LocalDateTime startAt;
 
     @NotNull
     @Column(name = "end_at", nullable = false)
+    @Getter
     private LocalDateTime endAt;
 
     @Column(name = "tags", length = RecruitmentValidationConstant.TAG_MAX_LENGTH, nullable = false)
+    @Getter
     private String tags;
 
     @Getter

--- a/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
+++ b/src/main/java/com/dongsoop/dongsoop/board/RecruitmentBoard.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+@Getter
 @MappedSuperclass
 @SuperBuilder
 @NoArgsConstructor
@@ -16,19 +17,15 @@ public abstract class RecruitmentBoard extends Board {
 
     @NotNull
     @Column(name = "start_at", nullable = false)
-    @Getter
     private LocalDateTime startAt;
 
     @NotNull
     @Column(name = "end_at", nullable = false)
-    @Getter
     private LocalDateTime endAt;
 
     @Column(name = "tags", length = RecruitmentValidationConstant.TAG_MAX_LENGTH, nullable = false)
-    @Getter
     private String tags;
 
-    @Getter
     @Column(name = "chat_room_id", length = 50)
     private String RoomId;
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/exception/ManagerLeaveRestrictedException.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/exception/ManagerLeaveRestrictedException.java
@@ -1,0 +1,15 @@
+package com.dongsoop.dongsoop.chat.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.http.HttpStatus;
+
+public class ManagerLeaveRestrictedException extends CustomException {
+
+    public ManagerLeaveRestrictedException(LocalDateTime recruitmentEndAt) {
+        super(String.format("모집 기간 중에는 매니저가 채팅방을 나갈 수 없습니다. 모집 종료일: %s",
+                        recruitmentEndAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))),
+                HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -58,6 +58,11 @@ public class ChatService {
     }
 
     public void leaveChatRoom(String roomId, Long userId) {
+        ChatRoom room = chatRoomService.getChatRoomById(roomId);
+        
+        chatValidator.validateUserForRoom(roomId, userId);
+        chatValidator.validateManagerCanLeave(room, userId);
+        
         chatParticipantService.leaveChatRoom(roomId, userId, chatRoomService, chatMessageService);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
@@ -133,7 +133,7 @@ public class ChatCommonUtils {
         String key = buildEndAtKey(roomId);
         String endAtStr = endAt.format(FORMATTER);
         
-        Duration ttl = Duration.between(LocalDateTime.now(), endAt.plusDays(7));
+        Duration ttl = Duration.between(LocalDateTime.now(), endAt.plusDays(1));
         redisTemplate.opsForValue().set(key, endAtStr, ttl);
         
         log.info("모집 채팅방 종료일 저장: roomId={}, endAt={}", roomId, endAt);

--- a/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
@@ -166,8 +166,8 @@ public class ChatValidator {
 
     private void validateRecruitmentPeriod(String roomId) {
         Optional<LocalDateTime> endAt = chatCommonUtils.getRecruitmentEndAt(roomId);
-        
-        if (!endAt.isPresent()) {
+
+        if (endAt.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/validator/ChatValidator.java
@@ -2,23 +2,17 @@ package com.dongsoop.dongsoop.chat.validator;
 
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
-import com.dongsoop.dongsoop.chat.exception.GroupChatOnlyException;
-import com.dongsoop.dongsoop.chat.exception.InvalidChatRequestException;
-import com.dongsoop.dongsoop.chat.exception.ManagerKickAttemptException;
-import com.dongsoop.dongsoop.chat.exception.ManagerLeaveRestrictedException;
-import com.dongsoop.dongsoop.chat.exception.SelfChatException;
-import com.dongsoop.dongsoop.chat.exception.UnauthorizedManagerActionException;
-import com.dongsoop.dongsoop.chat.exception.UserKickedException;
-import com.dongsoop.dongsoop.chat.exception.UserNotInRoomException;
+import com.dongsoop.dongsoop.chat.exception.*;
 import com.dongsoop.dongsoop.chat.repository.ChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatSyncService;
 import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
-import java.time.LocalDateTime;
-import java.util.Objects;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
 
 @Component
 public class ChatValidator {
@@ -167,11 +161,7 @@ public class ChatValidator {
     private void validateRecruitmentPeriod(String roomId) {
         Optional<LocalDateTime> endAt = chatCommonUtils.getRecruitmentEndAt(roomId);
 
-        if (endAt.isEmpty()) {
-            return;
-        }
-
-        if (isRecruitmentPeriodActive(endAt.get())) {
+        if (endAt.isPresent() && isRecruitmentPeriodActive(endAt.get())) {
             throw new ManagerLeaveRestrictedException(endAt.get());
         }
     }


### PR DESCRIPTION
## 관련 이슈

Closes #이슈번호

## 🎯 배경
- 모집 게시글의 매니저가 모집 기간 중에 혼자 채팅방을 나가는 경우, 다른 사용자들이 지원했을 때 매니저가 없어서 소통이 불가능한 상황이 발생했습니다.


## 🔍 주요 내용

- [x] ChatCommonUtils: Redis 기반 모집 종료일 관리 유틸리티 추가
- [x] ChatValidator: 매니저 나가기 제한 검증 로직 구현
- [x] ChatService: 채팅방 나가기 시 검증 로직 통합
- [x] BoardServiceImpl들: 게시글 생성 시 Redis에 모집 정보 저장
- [x] RecruitmentBoard: 필요한 시작일, 종료일 필드에 getter 메서드 추가

### 동작 시나리오
- **모집기간 중 + 혼자 있음** → 나가기 제한
- **모집기간 중 + 다른 사람 있음** → 나갈 수 있음
- **모집기간 종료 후** → 나갈 수 있음
- **일반 채팅방** → 제한 없음

- 모집기간 + 1일 후 TTL를 통한 만료 데이터 자동 삭제
## ⌛️ 리뷰 소요 시간

10분
