### PR TITLE
알림 전송 전 디바이스 목록 체크

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationSendServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/NotificationSendServiceImpl.java
@@ -171,12 +171,15 @@ public class NotificationSendServiceImpl implements NotificationSendService {
     @Override
     @Transactional(readOnly = true)
     public void send(MemberNotification memberNotification) {
-        // 알림을 보낼 대상 회원들
+        // 알림을 보낼 대상 회원
         Long memberId = memberNotification.getId()
                 .getMember()
                 .getId();
 
         List<String> deviceByMemberId = memberDeviceService.getDeviceByMemberId(memberId);
+        if (deviceByMemberId.isEmpty()) {
+            return;
+        }
 
         NotificationDetails details = memberNotification.getId()
                 .getDetails();


### PR DESCRIPTION
## 관련 이슈

Closes #218 

🎯 배경

- 알림을 보낼 디바이스가 없는 경우에도 FCM 알림을 전송하여 실패 예외 로그가 남는 문제

## 🔍 주요 내용

- [x] 디바이스 목록이 비어있는지 확인하여 비어있는 경우 바로 return

## ⌛️ 리뷰 소요 시간

0분
