### PR TITLE
학과별 공지 검색

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
@@ -50,4 +50,14 @@ public class SearchController {
         SearchResponse response = SearchDtoMapper.toSearchResponse(results);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/department-notice")
+    public ResponseEntity<SearchResponse> searchNoticesByDepartment(
+            @RequestParam String keyword,
+            @RequestParam String authorName,
+            Pageable pageable) {
+        Page<BoardDocument> results = boardSearchService.searchNoticesByDepartment(keyword, authorName, pageable);
+        SearchResponse response = SearchDtoMapper.toSearchResponse(results);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
@@ -56,8 +56,8 @@ public class SearchController {
             @RequestParam String keyword,
             @RequestParam String authorName,
             Pageable pageable) {
-        Page<BoardDocument> results = boardSearchService.searchNoticesByDepartment(keyword, authorName, pageable);
-        SearchResponse response = SearchDtoMapper.toSearchResponse(results);
+
+        SearchResponse response = boardSearchService.searchNoticesByDepartment(keyword, authorName, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/search/dto/BoardSearchResult.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/dto/BoardSearchResult.java
@@ -1,6 +1,5 @@
 package com.dongsoop.dongsoop.search.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,22 +15,12 @@ public class BoardSearchResult {
     private Long boardId;
     private String authorName;
     private String createdAt;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+
     private LocalDateTime recruitmentStartAt;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime recruitmentEndAt;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String marketplaceStatus;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String marketplaceType;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String noticeUrl;
-    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String tags;
+    private Long price;
 }

--- a/src/main/java/com/dongsoop/dongsoop/search/dto/SearchDtoMapper.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/dto/SearchDtoMapper.java
@@ -23,6 +23,7 @@ public class SearchDtoMapper {
                 .marketplaceType(document.getMarketplaceType())
                 .noticeUrl(getNoticeUrlByBoardType(document))
                 .tags(document.getTags())
+                .price(document.getPrice())
                 .build();
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/search/entity/BoardDocument.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/entity/BoardDocument.java
@@ -1,7 +1,6 @@
 package com.dongsoop.dongsoop.search.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -41,19 +40,15 @@ public class BoardDocument {
     private String createdAt;
 
     @Field(name = "recruitment_start_at", type = FieldType.Date)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime recruitmentStartAt;
 
     @Field(name = "recruitment_end_at", type = FieldType.Date)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime recruitmentEndAt;
 
     @Field(name = "marketplace_status", type = FieldType.Keyword)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String marketplaceStatus;
 
     @Field(name = "marketplace_type", type = FieldType.Keyword)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String marketplaceType;
 
     @Field(name = "link", type = FieldType.Keyword)
@@ -61,11 +56,12 @@ public class BoardDocument {
     private String link;
 
     @Field(type = FieldType.Keyword)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String tags;
 
+    @Field(type = FieldType.Integer)
+    private Long price;
+
     @JsonProperty("noticeUrl")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getNoticeUrl() {
         if (BoardType.NOTICE.getCode().equals(boardType)) {
             return link;
@@ -73,7 +69,6 @@ public class BoardDocument {
         return null;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getContent() {
         if (BoardType.NOTICE.getCode().equals(boardType)) {
             return null;

--- a/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
@@ -1,12 +1,13 @@
 package com.dongsoop.dongsoop.search.repository;
 
 import com.dongsoop.dongsoop.search.entity.BoardDocument;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocument, String> {
@@ -80,4 +81,27 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
             }
             """)
     Page<BoardDocument> findMarketplaceByKeywordAndType(String keyword, String marketplaceType, Pageable pageable);
+
+    @Query("""
+            {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {"match": {"title": {"query": "?0", "operator": "and"}}},
+                                    {"wildcard": {"title": "*?0*"}},
+                                    {"match": {"content": {"query": "?0", "operator": "and"}}},
+                                    {"wildcard": {"content": "*?0*"}}
+                                ],
+                                "minimum_should_match": 1
+                            }
+                        },
+                        {"term": {"board_type": "notice"}},
+                        {"term": {"author_name": "?1"}}
+                    ]
+                }
+            }
+            """)
+    Page<BoardDocument> findNoticesByKeywordAndAuthorName(String keyword, String authorName, Pageable pageable);
 }

--- a/src/main/java/com/dongsoop/dongsoop/search/service/BoardSearchService.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/service/BoardSearchService.java
@@ -117,7 +117,19 @@ public class BoardSearchService {
         }
     }
 
+    public Page<BoardDocument> searchNoticesByDepartment(String keyword, String authorName, Pageable pageable) {
+        String processedKeyword = preprocessKeyword(keyword);
+        if (processedKeyword.isEmpty()) {
+            return Page.empty(pageable);
+        }
 
+        try {
+            return boardSearchRepository.findNoticesByKeywordAndAuthorName(processedKeyword, authorName, pageable);
+        } catch (Exception e) {
+            logSearchError("searchNoticesByDepartment", processedKeyword, authorName, e);
+            return Page.empty(pageable);
+        }
+    }
 
     private void logSearchError(String operation, String keyword, String boardType, Exception e) {
         if (boardType != null) {


### PR DESCRIPTION
## 🎯 배경

- 이전에는 학교공지 전체를 조회를 하였지만 학과 공지사항을 조회하기에는 부적합하여 추가하게되었습니다.

## 🔍 주요 내용

- [x] 학과별 공지사항 조회를 추가하였습니다.
- [x] 학과별 조회시 ``` /search/department-notice?keyword=검색할키워드&authorName=학과이름``` 

## ⌛️ 리뷰 소요 시간

3분
