### PR TITLE
Feat/search

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/controller/SearchController.java
@@ -22,21 +22,13 @@ public class SearchController {
 
     private final BoardSearchService boardSearchService;
 
-    @GetMapping
-    public ResponseEntity<SearchResponse> searchAll(
-            @RequestParam String keyword,
-            Pageable pageable) {
-        Page<BoardDocument> results = boardSearchService.searchAll(keyword, pageable);
-        SearchResponse response = SearchDtoMapper.toSearchResponse(results);
-        return ResponseEntity.ok(response);
-    }
-
     @GetMapping("/by-type")
     public ResponseEntity<SearchResponse> searchByType(
             @RequestParam String keyword,
             @RequestParam BoardType boardType,
+            @RequestParam(required = false) String departmentName,
             Pageable pageable) {
-        Page<BoardDocument> results = boardSearchService.searchByBoardType(keyword, boardType, pageable);
+        Page<BoardDocument> results = boardSearchService.searchByBoardType(keyword, boardType, departmentName, pageable);
         SearchResponse response = SearchDtoMapper.toSearchResponse(results);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/dongsoop/dongsoop/search/entity/BoardDocument.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/entity/BoardDocument.java
@@ -61,6 +61,12 @@ public class BoardDocument {
     @Field(type = FieldType.Integer)
     private Long price;
 
+    @Field(name = "department_name", type = FieldType.Keyword)
+    private String departmentName;
+
+    @Field(name = "contact_count", type = FieldType.Integer)
+    private Integer contactCount;
+
     @JsonProperty("noticeUrl")
     public String getNoticeUrl() {
         if (BoardType.NOTICE.getCode().equals(boardType)) {

--- a/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
@@ -104,4 +104,24 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
             }
             """)
     Page<BoardDocument> findNoticesByKeywordAndAuthorName(String keyword, String authorName, Pageable pageable);
+
+    @Query("""
+            {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {"match": {"title": "?0"}},
+                                    {"match": {"content": "?0"}}
+                                ]
+                            }
+                        },
+                        {"term": {"board_type": "?1"}},
+                        {"term": {"department_name": "?2"}}
+                    ]
+                }
+            }
+            """)
+    Page<BoardDocument> findByKeywordAndBoardTypeAndDepartmentName(String keyword, String boardType, String departmentName, Pageable pageable);
 }


### PR DESCRIPTION
## 관련 이슈

#222 

## 🎯 배경

- 현재 검색 기능에서 회원의 학과별 게시글 필터링이 불가능함
- 프로젝트, 스터디, 튜터링 게시판에서 자신의 학과 게시글만 보고 싶은 요구사항 발생
- 마켓플레이스에서 문의 수가 표시되지 않는 문제

## 🔍 주요 내용
- [x] 검색 API에 학과별 필터링 기능 추가 (departmentName 파라미터)
- [x] 프로젝트/스터디/튜터링 게시판에서 학과명 기반 검색 지원
- [x] 마켓플레이스 게시글에 문의 수(contactCount) 표시 기능 추가
- [x] 전체 검색 기능 제거 (GET /search 엔드포인트 삭제)
- [x] Logstash 파이프라인에 학과 정보 조인 및 문의 수 계산 로직 추가
- [x] 삭제된 게시글 및 비활성 상태 게시글 검색 결과에서 제외
- [x] Elasticsearch 매핑에 departmentName, contactCount 필드 추가

## ⌛️ 리뷰 소요 시간

5분
