### PR TITLE
메일 전송 시 예외 처리 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/mailverify/exception/ReceiverMailNotAvailableException.java
+++ b/src/main/java/com/dongsoop/dongsoop/mailverify/exception/ReceiverMailNotAvailableException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.mailverify.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ReceiverMailNotAvailableException extends CustomException {
+
+    public ReceiverMailNotAvailableException(Throwable cause) {
+        super("수신자 메일이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, cause);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/mailverify/service/VerifyMailSender.java
+++ b/src/main/java/com/dongsoop/dongsoop/mailverify/service/VerifyMailSender.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.mailverify.service;
 
+import com.dongsoop.dongsoop.mailverify.exception.ReceiverMailNotAvailableException;
 import com.dongsoop.dongsoop.mailverify.exception.UnknownMailMessagingException;
 import com.dongsoop.dongsoop.mailverify.mailgenerator.MailTextGenerator;
 import jakarta.mail.MessagingException;
@@ -8,6 +9,7 @@ import java.time.Duration;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
@@ -66,6 +68,8 @@ public abstract class VerifyMailSender {
 
         try {
             sendMessage(userEmail, verifyCode);
+        } catch (MailSendException exception) {
+            throw new ReceiverMailNotAvailableException(exception);
         } catch (MessagingException exception) {
             throw new UnknownMailMessagingException(exception);
         }


### PR DESCRIPTION
## 관련 이슈

Closes #226

## 🎯 배경

- 잘못된 이메일 전송 시 SMTP 전송 과정에서 오류 발생

## 🔍 주요 내용

- [x] MailSenderException에 대한 catch 구문 추가

## ⌛️ 리뷰 소요 시간

0분
