### PR TITLE
장터채팅방 분리 및 채팅방 목록에 글로벌 WebSocket 알림 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatSocketController.java
@@ -48,6 +48,8 @@ public class ChatSocketController {
     public ChatMessage enterChatRoom(@DestinationVariable("roomId") String roomId, Principal principal) {
         Long userId = extractUserIdFromPrincipal(principal);
 
+        chatService.markAllMessagesAsRead(roomId, userId);
+
         ChatMessage enterMsg = chatService.processWebSocketEnter(roomId, userId);
         BlockStatus blockStatus = chatService.getBlockStatus(roomId, userId);
         chatService.sendBlockStatusToUser(roomId, userId, blockStatus);

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
@@ -1,0 +1,23 @@
+package com.dongsoop.dongsoop.chat.dto;
+
+import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomUpdateDto(
+        String type,
+        String roomId,
+        String lastMessage,
+        LocalDateTime timestamp,
+        Long senderId
+) {
+    public static ChatRoomUpdateDto createRoomUpdate(String roomId, ChatMessage message) {
+        return new ChatRoomUpdateDto(
+                "ROOM_UPDATE",
+                roomId,
+                message.getContent(),
+                message.getTimestamp(),
+                message.getSenderId()
+        );
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
@@ -1,11 +1,12 @@
 package com.dongsoop.dongsoop.chat.dto;
 
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+import com.dongsoop.dongsoop.chat.entity.ChatNotificationType;
 
 import java.time.LocalDateTime;
 
 public record ChatRoomUpdateDto(
-        String type,
+        ChatNotificationType type,
         String roomId,
         String lastMessage,
         LocalDateTime timestamp,
@@ -14,7 +15,7 @@ public record ChatRoomUpdateDto(
 ) {
     public static ChatRoomUpdateDto createRoomUpdate(String roomId, ChatMessage message, Integer unreadCount) {
         return new ChatRoomUpdateDto(
-                "ROOM_UPDATE",
+                ChatNotificationType.ROOM_UPDATE,
                 roomId,
                 message.getContent(),
                 message.getTimestamp(),

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/ChatRoomUpdateDto.java
@@ -9,15 +9,17 @@ public record ChatRoomUpdateDto(
         String roomId,
         String lastMessage,
         LocalDateTime timestamp,
-        Long senderId
+        Long senderId,
+        Integer unreadCount
 ) {
-    public static ChatRoomUpdateDto createRoomUpdate(String roomId, ChatMessage message) {
+    public static ChatRoomUpdateDto createRoomUpdate(String roomId, ChatMessage message, Integer unreadCount) {
         return new ChatRoomUpdateDto(
                 "ROOM_UPDATE",
                 roomId,
                 message.getContent(),
                 message.getTimestamp(),
-                message.getSenderId()
+                message.getSenderId(),
+                unreadCount
         );
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatNotificationType.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/entity/ChatNotificationType.java
@@ -1,0 +1,6 @@
+package com.dongsoop.dongsoop.chat.entity;
+
+public enum ChatNotificationType {
+    ROOM_UPDATE,
+    READ_STATUS_UPDATE
+}

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -134,7 +134,21 @@ public class ChatRoomService {
         return saveRoom(room);
     }
 
+    private String buildChatRoomTitle(RecruitmentType boardType, String boardTitle) {
+        String prefix = "문의";
+
+        if (boardType == null) {
+            prefix = "거래";
+        }
+
+        return String.format("[%s] %s", prefix, boardTitle);
+    }
+
     private void validateRecruitmentBoard(RecruitmentType boardType, Long boardId) {
+        if (boardType == null) {
+            return;
+        }
+
         boolean projectExists = boardType == RecruitmentType.PROJECT && projectBoardRepository.existsById(boardId);
         boolean studyExists = boardType == RecruitmentType.STUDY && studyBoardRepository.existsById(boardId);
         boolean tutoringExists = boardType == RecruitmentType.TUTORING && tutoringBoardRepository.existsById(boardId);

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -126,7 +126,7 @@ public class ChatRoomService {
             return getChatRoomById(existingRoomId);
         }
 
-        String title = String.format("[문의] %s", boardTitle);
+        String title = buildChatRoomTitle(boardType, boardTitle);
         ChatRoom room = createNewOneToOneRoom(userId, targetUserId, title);
 
         ChatCommonUtils.saveContactRoomMapping(redisTemplate, userId, targetUserId, boardType, boardId, room.getRoomId());

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -88,7 +88,7 @@ public class ChatService {
         chatNotification.send(receiver, roomId, senderName, message.getContent());
     }
 
-    private void sendGlobalRoomUpdate(Set<Long> participants, String roomId, ChatMessage message) {  // 새로 추가
+    private void sendGlobalRoomUpdate(Set<Long> participants, String roomId, ChatMessage message) {
         for (Long participantId : participants) {
             sendRoomUpdateToUser(participantId, roomId, message);
         }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -12,16 +12,15 @@ import com.dongsoop.dongsoop.chat.validator.ChatValidator;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberblock.constant.BlockStatus;
 import com.dongsoop.dongsoop.memberblock.repository.MemberBlockRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -85,6 +84,9 @@ public class ChatService {
     }
 
     private void sendFcmNotification(Set<Long> receiver, String roomId, Long userId, ChatMessage message) {
+        if (receiver == null || receiver.isEmpty()) {
+            return;
+        }
         String senderName = memberService.getNicknameById(userId);
         chatNotification.send(receiver, roomId, senderName, message.getContent());
     }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatService.java
@@ -4,6 +4,7 @@ import com.dongsoop.dongsoop.chat.dto.BlockStatusMessage;
 import com.dongsoop.dongsoop.chat.dto.ChatRoomUpdateDto;
 import com.dongsoop.dongsoop.chat.dto.ReadStatusUpdateRequest;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
+import com.dongsoop.dongsoop.chat.entity.ChatNotificationType;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
 import com.dongsoop.dongsoop.chat.entity.ChatRoomInitResponse;
 import com.dongsoop.dongsoop.chat.notification.ChatNotification;
@@ -132,7 +133,7 @@ public class ChatService {
 
     private void sendReadStatusUpdateNotification(Long userId, String roomId, Long readerId) {
         Map<String, Object> readUpdate = Map.of(
-                "type", "READ_STATUS_UPDATE",
+                "type", ChatNotificationType.READ_STATUS_UPDATE,
                 "roomId", roomId,
                 "readerId", readerId,
                 "timestamp", LocalDateTime.now()

--- a/src/main/java/com/dongsoop/dongsoop/chat/session/WebSocketSessionManager.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/session/WebSocketSessionManager.java
@@ -9,12 +9,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public class WebSocketSessionManager {
 
     private final Map<Long, String> userSessions = new ConcurrentHashMap<>();
+    private final Map<String, Long> sessionToUser = new ConcurrentHashMap<>();
 
     public void addUserSession(Long userId, String sessionId) {
         userSessions.put(userId, sessionId);
+        sessionToUser.put(sessionId, userId);
     }
 
     public void removeSession(String sessionId) {
-        userSessions.entrySet().removeIf(entry -> entry.getValue().equals(sessionId));
+        Long userId = sessionToUser.remove(sessionId);
+        if (userId != null) {
+            userSessions.remove(userId);
+        }
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/session/WebSocketSessionManager.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/session/WebSocketSessionManager.java
@@ -1,0 +1,20 @@
+package com.dongsoop.dongsoop.chat.session;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class WebSocketSessionManager {
+
+    private final Map<Long, String> userSessions = new ConcurrentHashMap<>();
+
+    public void addUserSession(Long userId, String sessionId) {
+        userSessions.put(userId, sessionId);
+    }
+
+    public void removeSession(String sessionId) {
+        userSessions.entrySet().removeIf(entry -> entry.getValue().equals(sessionId));
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/common/handler/websocket/StompHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/handler/websocket/StompHandler.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.common.handler.websocket;
 
 import com.dongsoop.dongsoop.chat.exception.UnauthorizedChatAccessException;
+import com.dongsoop.dongsoop.chat.session.WebSocketSessionManager;
 import com.dongsoop.dongsoop.jwt.JwtUtil;
 import com.dongsoop.dongsoop.jwt.JwtValidator;
 import com.dongsoop.dongsoop.jwt.dto.AuthenticationInformationByToken;
@@ -26,22 +27,25 @@ public class StompHandler implements ChannelInterceptor {
 
     private final JwtValidator jwtValidator;
     private final JwtUtil jwtUtil;
+    private final WebSocketSessionManager sessionManager;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-
-        if (accessor == null) {
-            return message;
-        }
 
         processCommand(accessor, accessor.getCommand());
         return message;
     }
 
     private void processCommand(StompHeaderAccessor accessor, StompCommand command) {
+        if (accessor == null) {
+            return;
+        }
         if (StompCommand.CONNECT == command) {
             authenticateConnection(accessor);
+        }
+        if (StompCommand.DISCONNECT == command) {  // 추가
+            handleDisconnect(accessor);
         }
     }
 
@@ -49,6 +53,24 @@ public class StompHandler implements ChannelInterceptor {
         String token = extractToken(accessor);
         validateToken(token);
         setAuthentication(accessor, token);
+
+        Long userId = getUserIdFromToken(token);
+        String sessionId = accessor.getSessionId();
+
+        if (sessionId != null) {
+            sessionManager.addUserSession(userId, sessionId);
+        }
+    }
+
+    private void handleDisconnect(StompHeaderAccessor accessor) {
+        String sessionId = accessor.getSessionId();
+        if (sessionId != null) {
+            sessionManager.removeSession(sessionId);
+        }
+    }
+
+    private Long getUserIdFromToken(String token) {
+        return jwtUtil.getTokenInformation(token).getId();
     }
 
     private String extractToken(StompHeaderAccessor accessor) {

--- a/src/main/java/com/dongsoop/dongsoop/common/handler/websocket/StompHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/handler/websocket/StompHandler.java
@@ -44,7 +44,7 @@ public class StompHandler implements ChannelInterceptor {
         if (StompCommand.CONNECT == command) {
             authenticateConnection(accessor);
         }
-        if (StompCommand.DISCONNECT == command) {  // 추가
+        if (StompCommand.DISCONNECT == command) {
             handleDisconnect(accessor);
         }
     }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
@@ -1,6 +1,8 @@
 package com.dongsoop.dongsoop.marketplace.service;
 
+import com.dongsoop.dongsoop.chat.service.ChatRoomService;
 import com.dongsoop.dongsoop.marketplace.dto.ContactMarketplaceRequest;
+import com.dongsoop.dongsoop.marketplace.entity.MarketplaceBoard;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceContact;
 import com.dongsoop.dongsoop.marketplace.exception.MarketplaceAlreadyContactException;
 import com.dongsoop.dongsoop.marketplace.exception.MarketplaceBoardNotFoundException;
@@ -25,6 +27,8 @@ public class MarketplaceContactServiceImpl implements MarketplaceContactService 
 
     private final MemberService memberService;
 
+    private final ChatRoomService chatRoomService;
+
     public void contact(ContactMarketplaceRequest request) {
         Long boardId = request.boardId();
 
@@ -32,6 +36,8 @@ public class MarketplaceContactServiceImpl implements MarketplaceContactService 
 
         Long memberId = memberService.getMemberIdByAuthentication();
         validateAlreadyContact(memberId, boardId);
+
+        createMarketplaceChatRoom(memberId, boardId);
 
         MarketplaceContact marketplaceContact = marketplaceContactMapper.toEntity(request);
         marketplaceContactRepository.save(marketplaceContact);
@@ -51,5 +57,24 @@ public class MarketplaceContactServiceImpl implements MarketplaceContactService 
         if (isAlreadyApplied) {
             throw new MarketplaceAlreadyContactException(memberId, boardId);
         }
+    }
+
+    private void createMarketplaceChatRoom(Long buyerId, Long boardId) {
+        Long sellerId = getSellerIdByBoardId(boardId);
+        String boardTitle = getBoardTitleById(boardId);
+
+        chatRoomService.createContactChatRoom(buyerId, sellerId, null, boardId, boardTitle);
+    }
+
+    private Long getSellerIdByBoardId(Long boardId) {
+        return marketplaceBoardRepository.findById(boardId)
+                .map(board -> board.getAuthor().getId())
+                .orElseThrow(() -> new MarketplaceBoardNotFoundException(boardId));
+    }
+
+    private String getBoardTitleById(Long boardId) {
+        return marketplaceBoardRepository.findById(boardId)
+                .map(MarketplaceBoard::getTitle)
+                .orElseThrow(() -> new MarketplaceBoardNotFoundException(boardId));
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
@@ -60,21 +60,22 @@ public class MarketplaceContactServiceImpl implements MarketplaceContactService 
     }
 
     private void createMarketplaceChatRoom(Long buyerId, Long boardId) {
-        Long sellerId = getSellerIdByBoardId(boardId);
-        String boardTitle = getBoardTitleById(boardId);
-
-        chatRoomService.createContactChatRoom(buyerId, sellerId, null, boardId, boardTitle);
+        SellerIdAndTitle sellerInfo = getSellerIdAndTitleByBoardId(boardId);
+        chatRoomService.createContactChatRoom(
+                buyerId,
+                sellerInfo.sellerId(),
+                null,
+                boardId,
+                sellerInfo.title()
+        );
     }
 
-    private Long getSellerIdByBoardId(Long boardId) {
-        return marketplaceBoardRepository.findById(boardId)
-                .map(board -> board.getAuthor().getId())
+    private SellerIdAndTitle getSellerIdAndTitleByBoardId(Long boardId) {
+        MarketplaceBoard board = marketplaceBoardRepository.findById(boardId)
                 .orElseThrow(() -> new MarketplaceBoardNotFoundException(boardId));
+        return new SellerIdAndTitle(board.getAuthor().getId(), board.getTitle());
     }
 
-    private String getBoardTitleById(Long boardId) {
-        return marketplaceBoardRepository.findById(boardId)
-                .map(MarketplaceBoard::getTitle)
-                .orElseThrow(() -> new MarketplaceBoardNotFoundException(boardId));
+    private record SellerIdAndTitle(Long sellerId, String title) {
     }
 }


### PR DESCRIPTION
#223 

## 🎯 배경
### 채팅방 목록
- 기존 채팅방 목록은 새로운 메시지가 올 때마다 /chat/rooms API를 재호출해야 했음
- 사용자가 목록 화면에서 다른 채팅방의 새 메시지를 실시간으로 확인할 수 없었음
- HTTP 폴링 방식으로 인한 불필요한 네트워크 요청과 리소스 소모 발생
- 앱 사용성 개선을 위해 실시간 채팅방 목록 업데이트 기능이 필요했음

### 장터
- 장터 게시글에서 "거래하기" 클릭시 기존 1:1 채팅방으로 연결되어 이전 대화내역과 섞임
- 장터 거래와 일반 개인 대화 구분 불가능

## 🔍 주요 내용
### 채팅방 목록
- [x] WebSocket 세션 관리를 위한 WebSocketSessionManager 컴포넌트 추가
- [x] 타입 안전성을 위한 ChatRoomUpdateDto 레코드 생성 및 Map 기반 방식 대체
- [x] StompHandler에 세션 등록/해제 로직 통합
- [x]  ChatService에 전역 채팅방 업데이트 알림 시스템 구현
- [x]  개인 알림 채널(/topic/user/{userId}) 구독을 통한 실시간 업데이트 기능
- [x] 기존 FCM 알림과 WebSocket 알림 로직 분리로 기능별 책임 명확화
- [x] 기존 채팅 기능과의 완전한 호환성 유지

### 장터
- [x] 장터 문의시 [거래] 게시글제목 형태의 전용 채팅방 자동 생성
- [x] 기존 1:1 채팅과 완전 분리하여 거래 전용 공간 제공
- [x] 같은 게시글에 대해서는 기존 거래 채팅방 재사용

## ⌛️ 리뷰 소요 시간

10분
