### PR TITLE
교차 학과 모집 게시글 검색 지원 및 한글-영어 혼합 텍스트 검색 개선

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
@@ -118,7 +118,14 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
                             }
                         },
                         {"term": {"board_type": "?1"}},
-                        {"term": {"department_name": "?2"}}
+                        {
+                            "bool": {
+                                "should": [
+                                    {"term": {"department_name": "?2"}},
+                                    {"match_phrase": {"tags": "?2"}}
+                                ]
+                            }
+                        }
                     ]
                 }
             }

--- a/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
@@ -36,7 +36,7 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
                                 ]
                             }
                         },
-                        {"term": {"board_type": "?1"}}
+                        {"match": {"board_type": "?1"}}
                     ]
                 }
             }
@@ -113,11 +113,13 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
                             "bool": {
                                 "should": [
                                     {"match": {"title": "?0"}},
-                                    {"match": {"content": "?0"}}
+                                    {"match": {"content": "?0"}},
+                                    {"wildcard": {"title": "*?0*"}},
+                                    {"wildcard": {"content": "*?0*"}}
                                 ]
                             }
                         },
-                        {"term": {"board_type": "?1"}},
+                        {"match": {"board_type": "?1"}},
                         {
                             "bool": {
                                 "should": [


### PR DESCRIPTION
## 🎯 배경

기존 시스템에서는 게시글 생성 시 자신의 학과 및 다른 학과를 대상으로 모집할 수 있도록 departmentTypeList 기능이 구현되어 있었습니다. 게시판 목록에서는 정상적으로 작동하여 선택된 다른 학과에서도 해당 게시글을 볼 수 있었습니다.
하지만 검색 기능에서는 학과 태그 목록이 누락되어 다음과 같은 문제가 발생함

- 컴퓨터소프트웨어공학과 학생이 게시글 작성
- departmentTypeList에 웹응용소프트웨어공학과, 인공지능소프트웨어학과 포함
- 게시판 목록: 웹응용소프트웨어공학과 학생들도 해당 글을 볼 수 있음
- 검색: 웹응용소프트웨어공학과로 검색하면 해당 글이 검색되지 않음

## 🔍 주요 내용
- 서버속 logstash에 departmentTypeList 등록
- 기존 게시판 목록 기능은 그대로 유지하면서 검색 기능의 일관성 확보
- PROJECT/STUDY/TUTORING 검색 성능 및 정확도 향상
- 한글-영어 혼합 키워드 검색 지원 강화

## ⌛️ 리뷰 소요 시간

2분
