### PR TITLE
refactor: replace RecruitmentType with BoardType in contact chat system

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateContactRoomRequest.java
@@ -1,6 +1,6 @@
 package com.dongsoop.dongsoop.chat.dto;
 
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateContactRoomRequest {
     private Long targetUserId;
-    private RecruitmentType boardType;
+    private BoardType boardType;
     private Long boardId;
     private String boardTitle;
 }

--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -6,7 +6,7 @@ import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
 import com.dongsoop.dongsoop.chat.validator.ChatValidator;
 import com.dongsoop.dongsoop.marketplace.repository.MarketplaceBoardRepository;
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepository;
@@ -117,9 +117,9 @@ public class ChatRoomService {
         return saveRoom(room);
     }
 
-    public ChatRoom createContactChatRoom(Long userId, Long targetUserId, RecruitmentType boardType, Long boardId,
+    public ChatRoom createContactChatRoom(Long userId, Long targetUserId, BoardType boardType, Long boardId,
                                           String boardTitle) {
-        validateRecruitmentBoard(boardType, boardId);
+        validateBoard(boardType, boardId);
 
         String existingRoomId = ChatCommonUtils.findExistingContactRoomId(redisTemplate, userId, targetUserId, boardType, boardId);
         if (existingRoomId != null) {
@@ -134,24 +134,19 @@ public class ChatRoomService {
         return saveRoom(room);
     }
 
-    private String buildChatRoomTitle(RecruitmentType boardType, String boardTitle) {
-        String prefix = "문의";
-
-        if (boardType == null) {
-            prefix = "거래";
-        }
-
+    private String buildChatRoomTitle(BoardType boardType, String boardTitle) {
+        String prefix = boardType == BoardType.MARKETPLACE ? "거래" : "문의";
         return String.format("[%s] %s", prefix, boardTitle);
     }
 
-    private void validateRecruitmentBoard(RecruitmentType boardType, Long boardId) {
-        if (boardType == null) {
+    private void validateBoard(BoardType boardType, Long boardId) {
+        if (boardType == BoardType.MARKETPLACE) {
             return;
         }
 
-        boolean projectExists = boardType == RecruitmentType.PROJECT && projectBoardRepository.existsById(boardId);
-        boolean studyExists = boardType == RecruitmentType.STUDY && studyBoardRepository.existsById(boardId);
-        boolean tutoringExists = boardType == RecruitmentType.TUTORING && tutoringBoardRepository.existsById(boardId);
+        boolean projectExists = boardType == BoardType.PROJECT && projectBoardRepository.existsById(boardId);
+        boolean studyExists = boardType == BoardType.STUDY && studyBoardRepository.existsById(boardId);
+        boolean tutoringExists = boardType == BoardType.TUTORING && tutoringBoardRepository.existsById(boardId);
 
         boolean boardExists = projectExists || studyExists || tutoringExists;
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/util/ChatCommonUtils.java
@@ -3,7 +3,7 @@ package com.dongsoop.dongsoop.chat.util;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.MessageType;
 import com.dongsoop.dongsoop.chat.exception.UnauthorizedChatAccessException;
-import com.dongsoop.dongsoop.recruitment.RecruitmentType;
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -79,10 +79,8 @@ public class ChatCommonUtils {
         return str == null || str.trim().isEmpty();
     }
 
-    private static String createContactMappingKey(Long userId, Long targetUserId, RecruitmentType boardType, Long boardId) {
-        String boardTypeName = Optional.ofNullable(boardType)
-                .map(RecruitmentType::name)
-                .orElse(MARKETPLACE);
+    private static String createContactMappingKey(Long userId, Long targetUserId, BoardType boardType, Long boardId) {
+        String boardTypeName = boardType != null ? boardType.getCode() : MARKETPLACE;
 
         Long minUserId = Math.min(userId, targetUserId);
         Long maxUserId = Math.max(userId, targetUserId);
@@ -92,7 +90,7 @@ public class ChatCommonUtils {
 
     public static String findExistingContactRoomId(RedisTemplate<String, Object> redisTemplate,
                                                    Long userId, Long targetUserId,
-                                                   RecruitmentType boardType, Long boardId) {
+                                                   BoardType boardType, Long boardId) {
         String mappingKey = createContactMappingKey(userId, targetUserId, boardType, boardId);
         Object result = redisTemplate.opsForValue().get(mappingKey);
 
@@ -104,7 +102,7 @@ public class ChatCommonUtils {
 
     public static void saveContactRoomMapping(RedisTemplate<String, Object> redisTemplate,
                                               Long userId, Long targetUserId,
-                                              RecruitmentType boardType, Long boardId, String roomId) {
+                                              BoardType boardType, Long boardId, String roomId) {
         String mappingKey = createContactMappingKey(userId, targetUserId, boardType, boardId);
 
         // 기존: boardInfo → roomId 매핑
@@ -115,7 +113,7 @@ public class ChatCommonUtils {
         String boardInfo = String.format("%d:%d:%s:%d",
                 Math.min(userId, targetUserId),
                 Math.max(userId, targetUserId),
-                boardType.name(),
+                boardType.getCode(),
                 boardId);
         redisTemplate.opsForValue().set(reverseMappingKey, boardInfo);
     }

--- a/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/marketplace/service/MarketplaceContactServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.marketplace.service;
 
 import com.dongsoop.dongsoop.chat.service.ChatRoomService;
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import com.dongsoop.dongsoop.marketplace.dto.ContactMarketplaceRequest;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceBoard;
 import com.dongsoop.dongsoop.marketplace.entity.MarketplaceContact;
@@ -64,7 +65,7 @@ public class MarketplaceContactServiceImpl implements MarketplaceContactService 
         chatRoomService.createContactChatRoom(
                 buyerId,
                 sellerInfo.sellerId(),
-                null,
+                BoardType.MARKETPLACE,
                 boardId,
                 sellerInfo.title()
         );


### PR DESCRIPTION
## 🎯 배경

- 장터에서 거래하기 버튼 클릭 시 NullPointerException 발생
- RecruitmentType이 null인 상태에서 boardType.name() 호출로 인한 에러
- 타입 안전성 부족으로 런타임 오류 발생

## 🔍 주요 내용

- RecruitmentType을 BoardType enum으로 변경하여 null 안전성 확보
- ChatCommonUtils의 모든 contact 관련 메서드 수정
- ChatRoomService.buildChatRoomTitle 로직 단순화
- MarketplaceContactServiceImpl에서 BoardType.MARKETPLACE 명시적 전달
- CreateContactRoomRequest DTO BoardType 필드로 변경

## ⌛️ 리뷰 소요 시간

0분
