### PR TITLE
fix: 홈 공지 정렬 방식 개선 (공지 생성일 기준 정렬)

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notice/repository/NoticeRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.member.entity.QMember;
 import com.dongsoop.dongsoop.notice.dto.HomeNotice;
 import com.dongsoop.dongsoop.notice.entity.QNotice;
 import com.dongsoop.dongsoop.notice.entity.QNoticeDetails;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -34,7 +35,7 @@ public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
                 .innerJoin(notice.id.noticeDetails, noticeDetails)
                 .innerJoin(notice.id.department, department)
                 .where(notice.id.department.id.in(List.of(DepartmentType.DEPT_1001, departmentType))) // 사용자 학과 및 대학 공지
-                .orderBy(noticeDetails.id.desc())
+                .orderBy(orderLeastId())
                 .limit(3)
                 .fetch();
     }
@@ -50,8 +51,12 @@ public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
                 .innerJoin(notice.id.noticeDetails, noticeDetails)
                 .innerJoin(notice.id.department, department)
                 .where(notice.id.department.id.eq(DepartmentType.DEPT_1001)) // 대학 공지만
-                .orderBy(noticeDetails.id.desc())
+                .orderBy(orderLeastId())
                 .limit(3)
                 .fetch();
+    }
+
+    private OrderSpecifier<Long> orderLeastId() {
+        return noticeDetails.id.desc();
     }
 }


### PR DESCRIPTION
## 관련 이슈

(이슈 번호가 있다면 여기에 추가)

## 🎯 배경
- 홈 화면에서 공지 정렬 기준이 공지 공지 생성일(createdAt)에서 상세 id 기준으로 변경되었습니다.
- 사용자가 더 직관적으로 최신 공지를 확인할 수 있도록 개선했습니다.

## 🔍 주요 변경 내용
- [x] NoticeRepositoryCustomImpl에서 공지 정렬 기준을 noticeDetails.createdAt에서 noticeDetails.id으로 변경
   - DB에 저장된 시간이 아닌, 최신 공지 번호로 정렬
- [x] 대학 공지, 학과 공지 모두 동일하게 적용

## ⌛️ 리뷰 소요 시간
0분