### PR TITLE
feat: 웹 지원을 위한 로그인 기능 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,11 +70,13 @@ public class MemberController {
         String accessToken = issuedToken.getAccessToken();
         String refreshToken = issuedToken.getRefreshToken();
 
-        memberDeviceService.bindDeviceWithMemberId(
-                loginDetail.getLoginMemberDetail().getId(),
-                loginRequest.getFcmToken());
+        if (StringUtils.hasText(loginRequest.getFcmToken())) {
+            memberDeviceService.bindDeviceWithMemberId(
+                    loginDetail.getLoginMemberDetail().getId(),
+                    loginRequest.getFcmToken());
 
-        fcmService.unsubscribeTopic(List.of(loginRequest.getFcmToken()), anonymousTopic);
+            fcmService.unsubscribeTopic(List.of(loginRequest.getFcmToken()), anonymousTopic);
+        }
 
         LoginResponse loginResponse = new LoginResponse(loginDetail.getLoginMemberDetail(), accessToken, refreshToken);
         return ResponseEntity.ok(loginResponse);

--- a/src/main/java/com/dongsoop/dongsoop/member/dto/LoginRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/dto/LoginRequest.java
@@ -19,6 +19,5 @@ public class LoginRequest {
     @NotBlank(message = "로그인 시 비밀번호 입력은 필수입니다.")
     private String password;
 
-    @NotBlank(message = "FCM 토큰은 필수 입력값입니다.")
     private String fcmToken;
 }


### PR DESCRIPTION
## 관련 이슈

Closes #이슈번호

## 🎯 배경

- 웹 클라이언트에서 로그인 기능을 사용하도록 백엔드 로그인 흐름을 개선합니다.
- 웹에서는 FCM 토큰이 선택적이므로 로그인 처리 흐름을 웹에 맞게 조정했습니다.

## 🔍 주요 내용

- [x] /members/login 엔드포인트에서 fcmToken이 있을 때만 디바이스 바인딩 수행
- [x] 익명(anonymous) 토픽 구독 해제 로직 추가
- [x] LoginResponse에 Access/Refresh 토큰 포함하여 반환
- [x] 기존 모바일 흐름과의 호환성 유지

## ⌛️ 리뷰 소요 시간

10분