### PR TITLE
과팅채팅방 생성을 위한 boardType 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/search/entity/BoardType.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/entity/BoardType.java
@@ -11,7 +11,7 @@ public enum BoardType {
     TUTORING("TUTORING", "튜터링"),
     MARKETPLACE("MARKETPLACE", "마켓플레이스"),
     NOTICE("NOTICE", "공지사항"),
-    BLINEDATE("BLINEDATE", "과팅");
+    BLINDDATE("BLINDDATE", "과팅");
 
     private final String code;
     private final String displayName;


### PR DESCRIPTION
## 🎯 배경

- 과팅에서 사랑의 작대기로 매칭에 성사되었을시에 1:1채팅방 생성로직으로 하는데, 이때 기존에 1:1채팅한 내역이 있다면 해당 채팅방으로 찾아가는 로직이 포함되어 있어 제대로 채팅방이 생성되지않는 이슈가 발생

## 🔍 주요 내용

- [x] 과팅전용 타입추가 DLINEDATE

## ⌛️ 리뷰 소요 시간

1분
