### PR TITLE
fix(chat): Allow contact chat creation for BLINDDATE board type

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -6,10 +6,10 @@ import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import com.dongsoop.dongsoop.chat.util.ChatCommonUtils;
 import com.dongsoop.dongsoop.chat.validator.ChatValidator;
 import com.dongsoop.dongsoop.marketplace.repository.MarketplaceBoardRepository;
-import com.dongsoop.dongsoop.search.entity.BoardType;
 import com.dongsoop.dongsoop.recruitment.board.project.repository.ProjectBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.study.repository.StudyBoardRepository;
 import com.dongsoop.dongsoop.recruitment.board.tutoring.repository.TutoringBoardRepository;
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -140,7 +140,7 @@ public class ChatRoomService {
     }
 
     private void validateBoard(BoardType boardType, Long boardId) {
-        if (boardType == BoardType.MARKETPLACE) {
+        if (boardType == BoardType.MARKETPLACE || boardType == BoardType.BLINDDATE) {
             return;
         }
 


### PR DESCRIPTION
🎯 배경
- 외부 과팅(BLINDDATE) 서버에서 매칭이 성사되어 1:1 채팅방 생성을 요청(POST /chat/room/contact)할 때, 404 BoardNotFoundException 오류가 발생했습니다.

- 원인은 ChatRoomService의 validateBoard 메서드가 BLINDDATE 타입을 인식하지 못하고, boardId를 실제 게시판 DB에서 검증하려 했기 때문입니다.

- 이로 인해 과팅처럼 가상의 boardId를 사용하는 경우 채팅방이 생성되지 못하는 문제가 있었습니다.

🔍 주요 내용
- [x] search.entity.BoardType enum에 BLINDDATE 타입을 추가했습니다.

- [x] chat.service.ChatRoomService의 validateBoard 메서드를 수정하여, boardType이 BLINDDATE일 경우 MARKETPLACE와 동일하게 DB 존재 여부 검증을 건너뛰도록 변경했습니다.

⌛️ 리뷰 소요 시간
1분