### PR TITLE
fix(chat): Set correct chat room title prefix for BLINDDATE

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/service/ChatRoomService.java
@@ -135,8 +135,15 @@ public class ChatRoomService {
     }
 
     private String buildChatRoomTitle(BoardType boardType, String boardTitle) {
-        String prefix = boardType == BoardType.MARKETPLACE ? "거래" : "문의";
-        return String.format("[%s] %s", prefix, boardTitle);
+        if (boardType == BoardType.MARKETPLACE) {
+            return String.format("[거래] %s", boardTitle);
+        }
+
+        if (boardType == BoardType.BLINDDATE) {
+            return String.format("[과팅] %s", boardTitle);
+        }
+
+        return String.format("[문의] %s", boardTitle);
     }
 
     private void validateBoard(BoardType boardType, Long boardId) {


### PR DESCRIPTION
## 🎯 배경
- BLINDDATE 타입으로 POST /chat/room/contact API를 호출할 때, boardType 검증은 통과했지만 채팅방 제목이 [문의]로 잘못 생성되는 문제가 있었습니다.

- 이는 ChatRoomService의 buildChatRoomTitle 메서드가 MARKETPLACE 타입을 제외한 모든 boardType을 [문의]로 처리하고 있었기 때문입니다.

## 🔍 주요 내용
- [x] ChatRoomService.java의 buildChatRoomTitle 메서드 로직을 수정했습니다.

- [x] boardType이 BLINDDATE일 경우, 채팅방 제목에 [과팅] 접두사가 적용되도록 분기 처리를 추가했습니다.

⌛️ 리뷰 소요 시간
1분