### PR TITLE
재가입 회원 방지를 위한 회원탈퇴 가명처리 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/dto/DeleteMember.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/dto/DeleteMember.java
@@ -1,0 +1,7 @@
+package com.dongsoop.dongsoop.member.dto;
+
+public record DeleteMember(
+        Long memberId,
+        String passwordAlias
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.member.repository;
 
 import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.member.dto.DeleteMember;
 import com.dongsoop.dongsoop.member.dto.LoginMemberDetails;
 import com.dongsoop.dongsoop.member.entity.Member;
 import java.util.List;
@@ -10,7 +11,7 @@ public interface MemberRepositoryCustom {
 
     Optional<LoginMemberDetails> findLoginMemberDetailById(Long id);
 
-    long softDelete(Long id, String emailAlias, String passwordAlias);
+    long softDelete(DeleteMember deleteMember);
 
     List<Member> searchAllByDeviceNotEmpty();
 

--- a/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/repository/MemberRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.member.repository;
 
 import com.dongsoop.dongsoop.department.entity.Department;
+import com.dongsoop.dongsoop.member.dto.DeleteMember;
 import com.dongsoop.dongsoop.member.dto.LoginMemberDetails;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.entity.QMember;
@@ -51,16 +52,15 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     @Override
-    public long softDelete(Long id, String emailAlias, String passwordAlias) {
+    public long softDelete(DeleteMember deleteMember) {
         return queryFactory.update(member)
-                .set(member.email, emailAlias)
-                .set(member.nickname, this.nicknameAliasPrefix + id)
-                .set(member.password, passwordAlias)
+                .set(member.nickname, this.nicknameAliasPrefix + deleteMember.memberId())
+                .set(member.password, deleteMember.passwordAlias())
                 .setNull(member.studentId)
                 .set(member.isDeleted, true)
                 .set(member.updatedAt, LocalDateTime.now())
                 .where(member.isDeleted.eq(false)
-                        .and(member.id.eq(id)))
+                        .and(member.id.eq(deleteMember.memberId())))
                 .execute();
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.service.DepartmentService;
 import com.dongsoop.dongsoop.jwt.TokenGenerator;
 import com.dongsoop.dongsoop.jwt.dto.IssuedToken;
+import com.dongsoop.dongsoop.member.dto.DeleteMember;
 import com.dongsoop.dongsoop.member.dto.LoginAuthenticate;
 import com.dongsoop.dongsoop.member.dto.LoginDetails;
 import com.dongsoop.dongsoop.member.dto.LoginMemberDetails;
@@ -191,9 +192,10 @@ public class MemberServiceImpl implements MemberService {
         Long requesterId = getMemberIdByAuthentication();
 
         // 가명처리
-        String emailAlias = generateEmailAlias();
         String passwordAlias = generatePasswordAlias();
-        long updatedCount = memberRepository.softDelete(requesterId, emailAlias, passwordAlias);
+
+        DeleteMember deleteMember = new DeleteMember(requesterId, passwordAlias);
+        long updatedCount = memberRepository.softDelete(deleteMember);
         if (updatedCount == 0L) {
             log.error("Member with id {} not found or already deleted", requesterId);
             throw new MemberNotFoundException();


### PR DESCRIPTION
## 관련 이슈

Closes #249 

## 🎯 배경

- 회원 탈퇴 시 이메일을 가명처리하여 재가입 시 확인할 수 없는 문제

## 🔍 주요 내용

- [x] 이메일 가명처리 수정
- [x] 회원 삭제 메서드 파라미터 수정

## ⌛️ 리뷰 소요 시간

0분
