### PR TITLE
이메일 인증 실패 예외 수정

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/mailverify/exception/MissingMailVerifyException.java
+++ b/src/main/java/com/dongsoop/dongsoop/mailverify/exception/MissingMailVerifyException.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.mailverify.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class MissingMailVerifyException extends CustomException {
+
+    public MissingMailVerifyException(Integer minute) {
+        super(String.format("이메일 인증이 누락되었거나, 이메일 인증 후 가입 완료 시간(%d분)을 초과했습니다.\n다시 시도해주세요.", minute),
+                HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/mailverify/service/MailVerifier.java
+++ b/src/main/java/com/dongsoop/dongsoop/mailverify/service/MailVerifier.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.mailverify.service;
 
+import com.dongsoop.dongsoop.mailverify.exception.MissingMailVerifyException;
 import com.dongsoop.dongsoop.mailverify.exception.UsingAllMailVerifyOpportunityException;
 import com.dongsoop.dongsoop.mailverify.exception.VerifyMailCodeNotAvailableException;
 import java.time.Duration;
@@ -41,9 +42,10 @@ public abstract class MailVerifier {
         }
 
         // 인증 완료 후 만료 시간 추가
-        redisTemplate.expire(redisKey, Duration.ofSeconds(AUTH_SUCCESS_TTL_SECONDS));
         redisTemplate.opsForHash()
                 .put(redisKey, successKey, true);
+
+        redisTemplate.expire(redisKey, Duration.ofSeconds(AUTH_SUCCESS_TTL_SECONDS));
     }
 
     private void validateOpportunity(String redisKey) {
@@ -74,7 +76,7 @@ public abstract class MailVerifier {
         Boolean isSuccess = getTypedValueFromRedisHashAsType(redisKey, successKey, Boolean.class);
 
         if (isSuccess == null || !isSuccess) {
-            throw new VerifyMailCodeNotAvailableException();
+            throw new MissingMailVerifyException(AUTH_SUCCESS_TTL_SECONDS / 60);
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #이슈번호

## 🎯 배경

- 이메일 인증 후 [가입하기] 버튼 클릭 시 이메일 인증 성공 여부가 존재하지 않는다면 인증 코드가 잘못되었다는 예외가 출력됨
- 이메일 인증 시 5분 안에 이메일 인증을 했더라도, redis에서 데이터가 만료되어 회원가입이 불가능한 문제

## 🔍 주요 내용

- [x] 예외를 새로 정의하여 클라이언트에게 정확한 예외 발행
- [x] 이메일 인증 완료 시 redis 데이터 만료 시간 10분으로 수정

## ⌛️ 리뷰 소요 시간

1분
