### PR TITLE
fix(chat): Set correct chat room title prefix for BLINDDATE

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/controller/ChatController.java
@@ -1,13 +1,6 @@
 package com.dongsoop.dongsoop.chat.controller;
 
-import com.dongsoop.dongsoop.chat.dto.ChatRoomListResponse;
-import com.dongsoop.dongsoop.chat.dto.CreateChatRoomByAdminRequest;
-import com.dongsoop.dongsoop.chat.dto.CreateContactRoomRequest;
-import com.dongsoop.dongsoop.chat.dto.CreateGroupRoomRequest;
-import com.dongsoop.dongsoop.chat.dto.CreateRoomRequest;
-import com.dongsoop.dongsoop.chat.dto.InviteUserRequest;
-import com.dongsoop.dongsoop.chat.dto.KickUserRequest;
-import com.dongsoop.dongsoop.chat.dto.ReadStatusUpdateRequest;
+import com.dongsoop.dongsoop.chat.dto.*;
 import com.dongsoop.dongsoop.chat.entity.ChatMessage;
 import com.dongsoop.dongsoop.chat.entity.ChatRoom;
 import com.dongsoop.dongsoop.chat.entity.ChatRoomInitResponse;
@@ -18,18 +11,14 @@ import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.role.entity.RoleType;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -75,9 +64,15 @@ public class ChatController {
     @PostMapping("/room/admin")
     @Secured(RoleType.ADMIN_ROLE)
     public ResponseEntity<ChatRoom> createRoom(@RequestBody @Valid CreateChatRoomByAdminRequest request) {
-        Long currentUserId = request.sourceUserId();
-        Long targetUserId = request.targetUserId();
-        ChatRoom createdRoom = chatRoomService.createOneToOneChatRoom(currentUserId, targetUserId, request.title());
+
+        ChatRoom createdRoom = chatRoomService.createContactChatRoom(
+                request.sourceUserId(),
+                request.targetUserId(),
+                request.boardType(),
+                request.boardId(),
+                request.boardTitle()
+        );
+
         return ResponseEntity.ok(createdRoom);
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateChatRoomByAdminRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/chat/dto/CreateChatRoomByAdminRequest.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.chat.dto;
 
+import com.dongsoop.dongsoop.search.entity.BoardType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -15,6 +16,12 @@ public record CreateChatRoomByAdminRequest(
         Long targetUserId,
 
         @NotBlank
-        String title
+        String boardTitle,
+
+        @NotNull
+        BoardType boardType,
+
+        @NotNull
+        Long boardId
 ) {
 }


### PR DESCRIPTION
## 🎯 배경
- BLINDDATE 타입으로 POST /chat/room/contact API를 호출할 시 전달값에서 자신의 토큰에서 아이디값을 가져와야하는데 노드채팅서버에서는 알 방법이 없기때문에 이전 /chat/room/admin api 재사용 및 필드를 추가

## 🔍 주요 내용
- [x] ChatController: chat/room/admin api 재사용 
- [x] CreateChatRoomByAdminRequest : 자신의 아이디값 필드 및 보드타입등 필요한 필드 추가
## ⌛️ 리뷰 소요 시간
1분