### PR TITLE
학과명 매핑 문제 해결

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/department/entity/DepartmentType.java
+++ b/src/main/java/com/dongsoop/dongsoop/department/entity/DepartmentType.java
@@ -16,11 +16,11 @@ public enum DepartmentType {
 
     // 기계공학부
     DEPT_3001("MECHANICAL_ENGINEERING", "기계공학과"),
-    DEPT_3002("MECHANICAL_DESIGN_ENGINEERING", "로봇소프트웨어과"),
+    DEPT_3002("MECHANICAL_DESIGN_ENGINEERING", "기계설계공학과"),
 
     // 로봇자동화공학부
     DEPT_4001("AUTOMATION_ENGINEERING", "자동화공학과"),
-    DEPT_4002("ROBOTICS_SOFTWARE", "기계설계공학과"),
+    DEPT_4002("ROBOTICS_SOFTWARE", "로봇소프트웨어과"),
 
     // 전기전자통신공학부
     DEPT_5001("ELECTRICAL_ENGINEERING", "전기공학과"),


### PR DESCRIPTION
## 관련 이슈

Closes #253 

## 🎯 배경

- 공지사항 알림 발송 시 제목은 로봇소프트웨어과로 나오지만 내용은 기계설계공학과로 나오고 있었습니다.

## 🔍 주요 내용

- [x] 학과 ENUM에 작성된 로봇소프트웨어과, 기계설계공학과이름을 교체


## ⌛️ 리뷰 소요 시간

0분
