### PR TITLE
ci: Docker's source metadata change from openjdk:17-jdk-slim to eclip…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM FROM eclipse-temurin:17-jdk-jammy
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 
@@ -12,4 +12,5 @@ COPY build/libs/*.jar app.jar
 EXPOSE 8080
 
 ENTRYPOINT ["java", "-jar", "app.jar"]
+
 


### PR DESCRIPTION
## 🎯 배경

- github → Docker Official Images → openjdk
 도커에서 제공하는 openjdk가 deprecated 되었다고 명시되어있음
 공식 문서에서는 openjdk를 대체할 목록중 eclipse-temurin로 변경

## 🔍 주요 내용
- [x] eclipse쪽이 더 많은 다운로드 수와 안정적이고 더많은 업데이트가 되었음으로 eclipse-temurin :17로 변경하기로 결정
- [x] 도커 메타데이터가 변경된것에 따라 DockerFile 내용 속에서 FROM openjdk-17 에서 FROM eclipse-temurin:17-jdk-jammy으로 변경 
## ⌛️ 리뷰 소요 시간

0분
