### PR TITLE
마케팅 알림 타입 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/notification/constant/NotificationType.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/constant/NotificationType.java
@@ -11,7 +11,8 @@ public enum NotificationType {
     RECRUITMENT_PROJECT_APPLY_RESULT(true),
     RECRUITMENT_TUTORING_APPLY_RESULT(true),
     TIMETABLE(true),
-    CALENDAR(true);
+    CALENDAR(true),
+    MARKETING(false);
 
     private final boolean defaultActiveState;
 


### PR DESCRIPTION
## 관련 이슈

Closes #이슈번호

## 🎯 배경

- 과팅 알림 및 기타 앱 사용 관련 알림 전송 시 필요한 타입입니다.

## 🔍 주요 내용

- [x] 마케팅 타입을 enum에 추가하였습니다.

## ⌛️ 리뷰 소요 시간

0분
