### PR TITLE
hotfix: 순환참조 해결

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
@@ -11,7 +11,6 @@ import com.dongsoop.dongsoop.memberdevice.entity.MemberDeviceType;
 import com.dongsoop.dongsoop.memberdevice.exception.AlreadyRegisteredDeviceException;
 import com.dongsoop.dongsoop.memberdevice.exception.UnregisteredDeviceException;
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepository;
-import com.dongsoop.dongsoop.notification.service.FCMService;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collector;
@@ -22,8 +21,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +28,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class MemberDeviceServiceImpl implements MemberDeviceService {
 
     private final MemberDeviceRepository memberDeviceRepository;
-    private final FCMService fcmService;
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -63,15 +59,6 @@ public class MemberDeviceServiceImpl implements MemberDeviceService {
 
         // 트랜잭션 커밋 후 익명 토픽 구독 해제를 위해 이벤트 발행
         eventPublisher.publishEvent(new DeviceBoundEvent(deviceToken));
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeviceBound(DeviceBoundEvent event) {
-        try {
-            fcmService.unsubscribeTopic(List.of(event.deviceToken()), anonymousTopic);
-        } catch (Exception e) {
-            log.warn("Failed to unsubscribe device from anonymous topic", e);
-        }
     }
 
     private void validateDuplicateDeviceToken(String deviceToken) {


### PR DESCRIPTION
## 관련 이슈

Closes #278 

## 🎯 배경

- 빈 객체 간 순환참조로 인해 배포 시 오류가 발생하는 문제가 있었습니다.

## 🔍 주요 내용

- [x] MemberDeviceServiceImpl에서 사용되지 않는 메서드에서 FCMServiceImpl을 참조하여, 해당 메서드 및 의존성을 제거했습니다.

## ⌛️ 리뷰 소요 시간

0분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * FCM(Firebase Cloud Messaging) 통합이 제거되었습니다. 기기 등록 후 자동 구독 해제 기능이 더 이상 작동하지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->