### PR TITLE
Hotfix/circle reference

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/controller/MemberController.java
@@ -17,7 +17,6 @@ import com.dongsoop.dongsoop.notification.service.FCMService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
-@Slf4j
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
@@ -10,15 +10,12 @@ import com.dongsoop.dongsoop.memberdevice.entity.MemberDeviceType;
 import com.dongsoop.dongsoop.memberdevice.exception.AlreadyRegisteredDeviceException;
 import com.dongsoop.dongsoop.memberdevice.exception.UnregisteredDeviceException;
 import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepository;
-import com.dongsoop.dongsoop.notification.service.FCMService;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,12 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberDeviceServiceImpl implements MemberDeviceService {
 
     private final MemberDeviceRepository memberDeviceRepository;
-    private final FCMService fcmService;
     private final MemberRepository memberRepository;
-    private final ApplicationEventPublisher eventPublisher;
-
-    @Value("${notification.topic.anonymous}")
-    private String anonymousTopic;
 
     @Override
     public void registerDevice(String deviceToken, MemberDeviceType deviceType) {

--- a/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/notification/service/FCMServiceImpl.java
@@ -57,8 +57,6 @@ public class FCMServiceImpl implements FCMService {
         } catch (FirebaseMessagingException e) {
             log.error("Error unsubscribing from topic {}: {}", topic, e.getMessage());
             throw new NotificationSendException(e);
-        } catch (Exception e) {
-            log.warn("Failed to unsubscribe device from anonymous topic", e);
         }
     }
 

--- a/src/main/java/com/dongsoop/dongsoop/oauth/controller/OAuth2Controller.java
+++ b/src/main/java/com/dongsoop/dongsoop/oauth/controller/OAuth2Controller.java
@@ -70,7 +70,7 @@ public class OAuth2Controller {
 
         // 알림 구독 설정
         memberDeviceService.bindDeviceWithMemberId(memberId, request.deviceToken());
-        fcmService.unsubscribeTopic(List.of(request.deviceToken()), anonymousTopic);
+        this.unsubscribeAnonymous(request.deviceToken());
 
         // 로그인 시 필요한 데이터 생성
         LoginResponse loginResponse = oAuth2Service.acceptLogin(authentication, memberId);
@@ -97,7 +97,7 @@ public class OAuth2Controller {
         Long memberId = this.getMemberIdByAuthentication(authentication);
 
         memberDeviceService.bindDeviceWithMemberId(memberId, request.deviceToken());
-        fcmService.unsubscribeTopic(List.of(request.deviceToken()), anonymousTopic);
+        this.unsubscribeAnonymous(request.deviceToken());
 
         LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId);
         return ResponseEntity.ok(response);
@@ -109,7 +109,7 @@ public class OAuth2Controller {
         Long memberId = this.getMemberIdByAuthentication(authentication);
 
         memberDeviceService.bindDeviceWithMemberId(memberId, request.deviceToken());
-        fcmService.unsubscribeTopic(List.of(request.deviceToken()), anonymousTopic);
+        this.unsubscribeAnonymous(request.deviceToken());
 
         LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId);
         return ResponseEntity.ok(response);
@@ -120,7 +120,7 @@ public class OAuth2Controller {
         Authentication authentication = this.appleSocialProvider.login(request.token());
         Long memberId = this.getMemberIdByAuthentication(authentication);
         memberDeviceService.bindDeviceWithMemberId(memberId, request.deviceToken());
-        fcmService.unsubscribeTopic(List.of(request.deviceToken()), anonymousTopic);
+        this.unsubscribeAnonymous(request.deviceToken());
 
         LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId);
         return ResponseEntity.ok(response);
@@ -183,5 +183,9 @@ public class OAuth2Controller {
                 memberService.getMemberIdByAuthentication());
 
         return ResponseEntity.ok(socialAccountState);
+    }
+
+    private void unsubscribeAnonymous(String deviceToken) {
+        fcmService.unsubscribeTopic(List.of(deviceToken), anonymousTopic);
     }
 }


### PR DESCRIPTION
## 🔍 주요 내용

- [x] fcm 토큰에 대해 anonymous 알림 구독 해지 로직을 controller로 이동

## ⌛️ 리뷰 소요 시간

0분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 로그인 후 디바이스 바인딩 시 FCM 토큰 구독 상태가 올바르게 관리되도록 개선했습니다.

* **Refactor**
  * 알림 구독 해제 로직을 재구성했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->