### PR TITLE
feat(OAuth2Controller): Change providerType's type enum to String

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/oauth/exception/InvalidProviderTypeException.java
+++ b/src/main/java/com/dongsoop/dongsoop/oauth/exception/InvalidProviderTypeException.java
@@ -8,4 +8,8 @@ public class InvalidProviderTypeException extends CustomException {
     public InvalidProviderTypeException() {
         super("유효하지 않은 공급자 타입입니다.", HttpStatus.BAD_REQUEST);
     }
+
+    public InvalidProviderTypeException(String providerType) {
+        super("유효하지 않은 공급자 타입입니다: " + providerType, HttpStatus.BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #이슈번호

## 🎯 배경

- API 경로 내 소문자 사용에 따른 즉시 enum 으로 받을 수 없는 문제가 있습니다.

## 🔍 주요 내용

- [x] 소셜 계정 삭제 시 소셜 타입을 String으로 받도록 수정되었습니다.

## ⌛️ 리뷰 소요 시간

0분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 소셜 계정 연동 해제 시 제공자 유형 검증이 강화되어, 잘못된 제공자 입력 시 어떤 값이 잘못되었는지 포함한 더 명확한 오류 메시지가 반환됩니다.

* **Refactor**
  * 연동 해제 API가 제공자 값을 문자열로 처리하도록 변경되어 입력 검증 흐름이 단순화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->