### PR TITLE
AWS S3 -> Oracle Object Storage로 마이그레이션

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/s3/S3ServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/S3ServiceImpl.java
@@ -1,6 +1,8 @@
 package com.dongsoop.dongsoop.s3;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +45,11 @@ public class S3ServiceImpl implements S3Service {
                 putObjectRequest,
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize())
         );
+
+        String encodedPath = URLEncoder.encode(saveFilePath, StandardCharsets.UTF_8)
+                .replace("+", "%20") // 공백 처리
+                .replace("%2F", "/") // 슬래시 복구
+                .replace("%2f", "/");
 
         return String.format("https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
                 region, namespace, bucket, saveFilePath);

--- a/src/main/java/com/dongsoop/dongsoop/s3/config/S3Config.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/config/S3Config.java
@@ -45,10 +45,17 @@ public class S3Config {
     @Bean
     @Primary
     public S3Client s3Client() {
+        URI endpointUri;
+        try {
+            endpointUri = URI.create(endpoint);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("OCI Endpoint 설정이 올바르지 않습니다: " + endpoint, e);
+        }
+
         return S3Client.builder()
                 .credentialsProvider(customAwsCredentialsProvider())
                 .region(Region.of(region))
-                .endpointOverride(URI.create(endpoint))
+                .endpointOverride(endpointUri)
                 .forcePathStyle(true)
                 .build();
     }


### PR DESCRIPTION
## 🎯 배경

- AWS 프리티어 종료에 대비하여, 이미지 저장소를 비용 효율적인 Oracle Cloud Infrastructure(OCI) Object Storage로 마이그레이션합니다.

## 🔍 주요 내용

- [x] `endpointOverride`: AWS 기본 주소 대신 OCI 호환 엔드포인트를 바라보도록 설정했습니다.
- [x] `.forcePathStyle(true)`: OCI의 SSL 인증서 도메인 검증 이슈(`SSLPeerUnverifiedException`)를 해결하기 위해, URL 방식을 `Virtual-Hosted-Style`(주소 앞 버킷명)에서 `Path-Style`(주소 뒤 버킷명)로 변경했습니다.
- [x] 기존 AWS URL 형식(`bucket.s3.region.amazonaws.com`)을 OCI 형식(`endpoint/n/namespace/b/bucket/o/file`)에 맞게 수정했습니다.

## ⌛️ 리뷰 소요 시간

1분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 클라우드 스토리지 설정 체계가 개선되었습니다.
  * 업로드된 파일의 접근 URL 형식이 변경되어 새로운 오브젝트 스토리지 서비스 규격을 따릅니다.
  * 커스텀 스토리지 엔드포인트 구성이 추가되어 다양한 배포 환경에서 유연하게 연결할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->