### PR TITLE
fix: Enforce strict keyword matching with 'AND' operator in notices

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/search/repository/BoardSearchRepository.java
@@ -89,6 +89,7 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
                             "multi_match": {
                                 "query": "?0",
                                 "fields": ["title", "content"],
+                                "type": "cross_fields",
                                 "operator": "and"
                             }
                         },
@@ -108,6 +109,7 @@ public interface BoardSearchRepository extends ElasticsearchRepository<BoardDocu
                             "multi_match": {
                                 "query": "?0",
                                 "fields": ["title", "content"],
+                                "type": "cross_fields",
                                 "operator": "and"
                             }
                         },


### PR DESCRIPTION
## 🎯 배경

- **정확도 문제:** 공지사항 및 학과 검색 시, "이렇게"와 같은 단어가 ["이", "렇", "게"]로 형태소 분석될 때, 기본 OR 연산으로 인해 한 글자만 일치해도 관련 없는 문서가 노출되는 문제가 있었습니다.
- **필드 간 검색 제한:** 기본 `multi_match`(`best_fields`) 전략은 검색어가 제목 또는 내용 중 *한 필드*에 모두 포함되어야만 매칭되는 한계가 있었습니다. (예: "학교 축제" 검색 시 제목에 "학교", 내용에 "축제"가 있으면 검색 안 됨)

## 🔍 주요 내용

- [x] **BoardSearchRepository 쿼리 고도화**
  - 공지사항(`findNotices...`) 및 학과/게시판 복합 검색(`findByKeyword...`) 메서드 수정
  - **`"operator": "and"` 적용:** 검색어의 모든 형태소가 문서에 존재해야만 결과로 반환하도록 강제 (정확도 향상)
  - **`"type": "cross_fields"` 적용:** 제목(`title`)과 내용(`content`)을 하나의 큰 필드처럼 취급하여, 검색어가 두 필드에 나뉘어 있어도 매칭되도록 수정 (재현율 향상)

## ⌛️ 리뷰 소요 시간

２분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 검색 알고리즘을 다중 필드 통합(multi-field) 방식으로 개선하여 제목과 본문을 함께 고려한 검색 결과 제공
  * 보다 엄격한 조건 적용으로 관련성 높은 결과가 우선 노출되어 불필요한 검색 결과 감소
  * 마켓플레이스·공지 검색 동작은 기존과 호환성 유지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->