### PR TITLE
feat: 이클래스 과제 동기화 백엔드 구현

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/eclass/controller/EclassAssignmentController.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/controller/EclassAssignmentController.java
@@ -1,0 +1,41 @@
+package com.dongsoop.dongsoop.eclass.controller;
+
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentResponse;
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentSaveRequest;
+import com.dongsoop.dongsoop.eclass.service.EclassAssignmentService;
+import com.dongsoop.dongsoop.member.service.MemberService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/eclass/assignments")
+@RequiredArgsConstructor
+public class EclassAssignmentController {
+
+    private final EclassAssignmentService eclassAssignmentService;
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<List<EclassAssignmentResponse>> saveAssignments(
+            @Valid @RequestBody EclassAssignmentSaveRequest request) {
+        Long memberId = memberService.getMemberIdByAuthentication();
+        List<EclassAssignmentResponse> result = eclassAssignmentService.saveAssignments(memberId, request);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EclassAssignmentResponse>> getAssignments() {
+        Long memberId = memberService.getMemberIdByAuthentication();
+        List<EclassAssignmentResponse> result = eclassAssignmentService.getAssignments(memberId);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentItem.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentItem.java
@@ -1,0 +1,29 @@
+package com.dongsoop.dongsoop.eclass.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EclassAssignmentItem {
+
+    @NotBlank(message = "이클래스 과제 ID를 입력해주세요.")
+    private String eclassId;
+
+    private String courseId;
+
+    @NotBlank(message = "수업명을 입력해주세요.")
+    private String courseName;
+
+    @NotBlank(message = "과제명을 입력해주세요.")
+    private String title;
+
+    private String dueDate;
+
+    private boolean isSubmitted;
+
+    private String status;
+
+    private String link;
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentResponse.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentResponse.java
@@ -1,0 +1,22 @@
+package com.dongsoop.dongsoop.eclass.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EclassAssignmentResponse {
+
+    private Long id;
+    private String eclassId;
+    private String courseId;
+    private String courseName;
+    private String title;
+    private String dueDate;
+    private boolean isSubmitted;
+    private String status;
+    private String link;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentSaveRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/dto/EclassAssignmentSaveRequest.java
@@ -1,0 +1,16 @@
+package com.dongsoop.dongsoop.eclass.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EclassAssignmentSaveRequest {
+
+    @NotNull(message = "과제 목록이 필요합니다.")
+    @Valid
+    private List<EclassAssignmentItem> assignments;
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/entity/EclassAssignment.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/entity/EclassAssignment.java
@@ -1,0 +1,69 @@
+package com.dongsoop.dongsoop.eclass.entity;
+
+import com.dongsoop.dongsoop.common.BaseEntity;
+import com.dongsoop.dongsoop.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "eclass_assignment",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "eclass_id"})
+)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EclassAssignment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "eclass_id", nullable = false, length = 50)
+    private String eclassId;
+
+    @Column(name = "course_id", length = 50)
+    private String courseId;
+
+    @Column(name = "course_name", nullable = false, length = 200)
+    private String courseName;
+
+    @Column(name = "title", nullable = false, length = 500)
+    private String title;
+
+    @Column(name = "due_date", length = 200)
+    private String dueDate;
+
+    @Column(name = "is_submitted", nullable = false)
+    private boolean isSubmitted;
+
+    @Column(name = "status", length = 100)
+    private String status;
+
+    @Column(name = "link", length = 500)
+    private String link;
+
+    public void update(String dueDate, boolean isSubmitted, String status) {
+        this.dueDate = dueDate;
+        this.isSubmitted = isSubmitted;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/repository/EclassAssignmentRepository.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/repository/EclassAssignmentRepository.java
@@ -1,0 +1,13 @@
+package com.dongsoop.dongsoop.eclass.repository;
+
+import com.dongsoop.dongsoop.eclass.entity.EclassAssignment;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EclassAssignmentRepository extends JpaRepository<EclassAssignment, Long> {
+
+    List<EclassAssignment> findByMemberIdAndIsDeletedFalseOrderByCreatedAtDesc(Long memberId);
+
+    Optional<EclassAssignment> findByMemberIdAndEclassIdAndIsDeletedFalse(Long memberId, String eclassId);
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/service/EclassAssignmentService.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/service/EclassAssignmentService.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.eclass.service;
+
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentResponse;
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentSaveRequest;
+import java.util.List;
+
+public interface EclassAssignmentService {
+
+    List<EclassAssignmentResponse> saveAssignments(Long memberId, EclassAssignmentSaveRequest request);
+
+    List<EclassAssignmentResponse> getAssignments(Long memberId);
+}

--- a/src/main/java/com/dongsoop/dongsoop/eclass/service/EclassAssignmentServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/eclass/service/EclassAssignmentServiceImpl.java
@@ -1,0 +1,80 @@
+package com.dongsoop.dongsoop.eclass.service;
+
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentItem;
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentResponse;
+import com.dongsoop.dongsoop.eclass.dto.EclassAssignmentSaveRequest;
+import com.dongsoop.dongsoop.eclass.entity.EclassAssignment;
+import com.dongsoop.dongsoop.eclass.repository.EclassAssignmentRepository;
+import com.dongsoop.dongsoop.member.entity.Member;
+import com.dongsoop.dongsoop.member.exception.MemberNotFoundException;
+import com.dongsoop.dongsoop.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EclassAssignmentServiceImpl implements EclassAssignmentService {
+
+    private final EclassAssignmentRepository eclassAssignmentRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public List<EclassAssignmentResponse> saveAssignments(Long memberId, EclassAssignmentSaveRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        for (EclassAssignmentItem item : request.getAssignments()) {
+            Optional<EclassAssignment> existing = eclassAssignmentRepository
+                    .findByMemberIdAndEclassIdAndIsDeletedFalse(memberId, item.getEclassId());
+
+            if (existing.isPresent()) {
+                existing.get().update(item.getDueDate(), item.isSubmitted(), item.getStatus());
+            } else {
+                EclassAssignment assignment = EclassAssignment.builder()
+                        .member(member)
+                        .eclassId(item.getEclassId())
+                        .courseId(item.getCourseId())
+                        .courseName(item.getCourseName())
+                        .title(item.getTitle())
+                        .dueDate(item.getDueDate())
+                        .isSubmitted(item.isSubmitted())
+                        .status(item.getStatus())
+                        .link(item.getLink())
+                        .build();
+                eclassAssignmentRepository.save(assignment);
+            }
+        }
+
+        return getAssignments(memberId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EclassAssignmentResponse> getAssignments(Long memberId) {
+        return eclassAssignmentRepository
+                .findByMemberIdAndIsDeletedFalseOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private EclassAssignmentResponse toResponse(EclassAssignment assignment) {
+        return new EclassAssignmentResponse(
+                assignment.getId(),
+                assignment.getEclassId(),
+                assignment.getCourseId(),
+                assignment.getCourseName(),
+                assignment.getTitle(),
+                assignment.getDueDate(),
+                assignment.isSubmitted(),
+                assignment.getStatus(),
+                assignment.getLink(),
+                assignment.getCreatedAt(),
+                assignment.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- 이클래스(Moodle) 과제 스크래핑 데이터를 저장/조회하는 백엔드 구현
- 프론트엔드 프록시 팝업에서 수집한 과제 정보를 DB에 upsert 저장

## 변경 사항
- `EclassAssignment` 엔티티: member + eclassId 유니크 제약으로 중복 저장 방지
- `POST /eclass/assignments`: 스크래핑된 과제 목록 일괄 저장 (기존 항목은 update)
- `GET /eclass/assignments`: 로그인 사용자의 저장된 과제 목록 반환

## 연관 PR
- web: dongsooop/web#6

## Test plan
- [ ] POST /eclass/assignments 저장 및 중복 upsert 동작 확인
- [ ] GET /eclass/assignments 사용자별 조회 확인
- [ ] 미인증 요청 401 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)