### PR TITLE
feat: auto-register web device with UUID on social login

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceService.java
@@ -12,7 +12,7 @@ public interface MemberDeviceService {
 
     void bindDeviceWithMemberId(Long memberId, String deviceToken);
 
-    void createAndBindWebDevice(Long memberId, String deviceToken);
+    String createAndBindWebDevice(Long memberId, String deviceToken);
 
     void updateLastAccessAsync(Long deviceId);
 

--- a/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/memberdevice/service/MemberDeviceServiceImpl.java
@@ -15,6 +15,7 @@ import com.dongsoop.dongsoop.memberdevice.repository.MemberDeviceRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -64,24 +65,27 @@ public class MemberDeviceServiceImpl implements MemberDeviceService {
     }
 
     // 새로운 WEB 바인딩 메서드: WEB 로그인 흐름에서 디바이스 행을 직접 생성하고 회원을 바인딩한다.
+    // deviceToken이 없으면 UUID를 생성하여 사용하고, 실제로 사용된 토큰을 반환한다.
     @Override
     @Transactional
-    public void createAndBindWebDevice(Long memberId, String deviceToken) {
+    public String createAndBindWebDevice(Long memberId, String deviceToken) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        // 토큰이 비어있지 않으면 중복 검증
-        if (deviceToken != null && !deviceToken.isBlank()) {
-            validateDuplicateDeviceToken(deviceToken);
-        }
+        String effectiveToken = (deviceToken != null && !deviceToken.isBlank())
+                ? deviceToken
+                : UUID.randomUUID().toString();
+
+        validateDuplicateDeviceToken(effectiveToken);
 
         MemberDevice memberDevice = MemberDevice.builder()
-                .deviceToken(deviceToken)
+                .deviceToken(effectiveToken)
                 .memberDeviceType(MemberDeviceType.WEB)
                 .member(member)
                 .build();
 
         memberDeviceRepository.save(memberDevice);
+        return effectiveToken;
     }
 
     private void validateDuplicateDeviceToken(String deviceToken) {

--- a/src/main/java/com/dongsoop/dongsoop/oauth/controller/OAuth2Controller.java
+++ b/src/main/java/com/dongsoop/dongsoop/oauth/controller/OAuth2Controller.java
@@ -83,9 +83,9 @@ public class OAuth2Controller {
         Authentication authentication = this.kakaoSocialProvider.login(request.token());
         Long memberId = this.getMemberIdByAuthentication(authentication);
 
-        bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
+        String effectiveToken = bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
 
-        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, request.deviceToken());
+        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, effectiveToken);
         return ResponseEntity.ok(response);
     }
 
@@ -94,9 +94,9 @@ public class OAuth2Controller {
         Authentication authentication = this.googleSocialProvider.login(request.token());
         Long memberId = this.getMemberIdByAuthentication(authentication);
 
-        bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
+        String effectiveToken = bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
 
-        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, request.deviceToken());
+        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, effectiveToken);
         return ResponseEntity.ok(response);
     }
 
@@ -105,9 +105,9 @@ public class OAuth2Controller {
         Authentication authentication = this.appleSocialProvider.login(request.token());
         Long memberId = this.getMemberIdByAuthentication(authentication);
 
-        bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
+        String effectiveToken = bindOrCreateDevice(memberId, request.deviceToken(), request.deviceType());
 
-        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, request.deviceToken());
+        LoginResponse response = oAuth2Service.acceptLogin(authentication, memberId, effectiveToken);
         return ResponseEntity.ok(response);
     }
 
@@ -177,13 +177,14 @@ public class OAuth2Controller {
         return ResponseEntity.ok(socialAccountState);
     }
 
-    private void bindOrCreateDevice(Long memberId, String deviceToken, MemberDeviceType deviceType) {
-        if (deviceType == MemberDeviceType.WEB) {
-            memberDeviceService.createAndBindWebDevice(memberId, deviceToken);
-        } else {
-            memberDeviceService.bindDeviceWithMemberId(memberId, deviceToken);
-            unsubscribeAnonymous(deviceToken);
+    private String bindOrCreateDevice(Long memberId, String deviceToken, MemberDeviceType deviceType) {
+        if (deviceType == MemberDeviceType.WEB || !org.springframework.util.StringUtils.hasText(deviceToken)) {
+            return memberDeviceService.createAndBindWebDevice(memberId, deviceToken);
         }
+
+        memberDeviceService.bindDeviceWithMemberId(memberId, deviceToken);
+        unsubscribeAnonymous(deviceToken);
+        return deviceToken;
     }
 
     private void unsubscribeAnonymous(String deviceToken) {

--- a/src/main/java/com/dongsoop/dongsoop/oauth/dto/SocialLoginRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/oauth/dto/SocialLoginRequest.java
@@ -8,7 +8,6 @@ public record SocialLoginRequest(
         @NotBlank
         String token,
 
-        @NotBlank
         String deviceToken,
 
         MemberDeviceType deviceType


### PR DESCRIPTION
## Summary
- `SocialLoginRequest.deviceToken` is no longer `@NotBlank` — web browsers may not have an FCM token
- `createAndBindWebDevice` generates a UUID when no device token is provided and returns the effective token used
- `bindOrCreateDevice` returns the effective token (UUID or original) so `acceptLogin` can resolve the correct `deviceId`
- Any request with `deviceType=WEB` or a missing/blank `deviceToken` routes through `createAndBindWebDevice`

## Flow (web social login)
1. Frontend calls `POST /oauth2/{provider}` with `deviceType=WEB`, `deviceToken` optional
2. If `deviceToken` is absent → UUID is generated server-side
3. Web device row is created and bound to the member immediately
4. `acceptLogin` looks up device by `memberId + effectiveToken` → embeds `deviceId` in JWT

## Test plan
- [ ] Web social login with no `deviceToken` → 200, JWT contains `did` claim
- [ ] Web social login with FCM `deviceToken` → 200, FCM token used as-is
- [ ] Mobile login (ANDROID/IOS) → existing flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹 기기 바인딩 시 기기 토큰이 자동으로 생성됩니다.
  * 로그인 시 기기 토큰을 선택적으로 제공할 수 있습니다.

* **버그 수정**
  * 기기 토큰 중복 검증 로직이 개선되었습니다.
  * 빈 기기 토큰에 대한 처리가 안정화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/backend/pull/329)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->