### PR TITLE
fix: resolve type mismatch in resolveDeviceId for WEB device

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/member/service/MemberServiceImpl.java
@@ -132,7 +132,10 @@ public class MemberServiceImpl implements MemberService {
             return null;
         }
         if (loginRequest.getDeviceType() == MemberDeviceType.WEB) {
-            return memberDeviceService.createAndBindWebDevice(memberId, fcmToken);
+            String webToken = memberDeviceService.createAndBindWebDevice(memberId, fcmToken);
+            return memberDeviceRepository.findByDeviceToken(webToken)
+                    .map(MemberDevice::getId)
+                    .orElse(null);
         }
         return memberDeviceRepository.findByDeviceToken(fcmToken)
                 .map(MemberDevice::getId)


### PR DESCRIPTION
## 원인

PR #329 (`feat: auto-register web device with UUID on social login`)가 CI 실패 상태로 main에 머지되면서 빌드가 깨진 상태입니다.

**에러 메시지:**
```
MemberServiceImpl.java:135: error: incompatible types: String cannot be converted to Long
    return memberDeviceService.createAndBindWebDevice(memberId, fcmToken);
```

`createAndBindWebDevice`는 `String`(토큰 값)을 반환하지만, `resolveDeviceId`의 반환 타입은 `Long`(device ID)이라 타입 불일치가 발생했습니다.

## 수정 내용

반환된 토큰 문자열로 DB에서 device ID를 조회하여 `Long` 타입으로 반환하도록 수정:

```java
// Before
return memberDeviceService.createAndBindWebDevice(memberId, fcmToken);

// After
String webToken = memberDeviceService.createAndBindWebDevice(memberId, fcmToken);
return memberDeviceRepository.findByDeviceToken(webToken)
        .map(MemberDevice::getId)
        .orElse(null);
```

## Test plan

- [ ] CI 빌드 통과 확인
- [ ] WEB 타입 소셜 로그인 시 JWT에 deviceId 정상 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 웹 플랫폼에서 디바이스 식별 관련 문제를 해결했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/backend/pull/330)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->