### PR TITLE
feat(security): P1 보안 강화 — WebSocket CORS, 파일 업로드 검증, Rate Limiting

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/common/config/SecurityConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.common.config;
 
 import com.dongsoop.dongsoop.common.handler.authentication.CustomAccessDeniedHandler;
 import com.dongsoop.dongsoop.common.handler.authentication.CustomAuthenticationEntryPoint;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.oauth.handler.OAuth2LoginFailureHandler;
 import com.dongsoop.dongsoop.oauth.handler.OAuth2LoginSuccessHandler;
@@ -28,6 +29,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+
+    private final RateLimitFilter rateLimitFilter;
 
     private final LogoutHandler logoutHandler;
 
@@ -72,6 +75,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable) // JWT를 사용하기 때문에 form login 비활성화
                 .addFilterBefore(jwtFilter, LogoutFilter.class)
+                .addFilterBefore(rateLimitFilter, JwtFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/java/com/dongsoop/dongsoop/common/config/WebSocketConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package com.dongsoop.dongsoop.common.config;
 import com.dongsoop.dongsoop.common.handler.websocket.CustomStompErrorHandler;
 import com.dongsoop.dongsoop.common.handler.websocket.StompHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -21,6 +22,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final StompHandler stompHandler;
     private final CustomStompErrorHandler customStompErrorHandler;
 
+    // REST CORS(SecurityConfig)와 동일한 출처 화이트리스트를 재사용하여 정책을 일원화한다.
+    @Value("${authentication.origins}")
+    private String[] allowedOrigins;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic", "/queue");
@@ -30,7 +35,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/chat", "/ws/blinddate")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS()
                 .setDisconnectDelay(30 * 1000)
                 .setHeartbeatTime(15 * 1000)

--- a/src/main/java/com/dongsoop/dongsoop/common/handler/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/handler/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 @Slf4j
@@ -38,6 +39,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ProblemDetail> handleGlobalException(MethodArgumentNotValidException exception) {
         return createExceptionResponse("요청 데이터의 포맷이 올바르지 않습니다.", exception, HttpStatus.BAD_REQUEST);
+    }
+
+    // 업로드 파일 크기 초과 (413 Payload Too Large) — 컨테이너가 FileValidator보다 먼저 던지는 예외 처리
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ProblemDetail> handleMaxUploadSize(MaxUploadSizeExceededException exception) {
+        return createExceptionResponse("업로드 가능한 파일 크기를 초과했습니다.", exception, HttpStatus.PAYLOAD_TOO_LARGE);
     }
 
     // 정의되지 않은 예외처리

--- a/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitFilter.java
@@ -1,0 +1,125 @@
+package com.dongsoop.dongsoop.common.ratelimit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 남용 위험이 높은 엔드포인트(로그인/이메일/검색)에 대해 클라이언트 IP 기준 요청 횟수를 제한한다.
+ *
+ * <p>Redis INCR + EXPIRE 고정 시간창 방식이라 멀티 인스턴스 배포에서도 카운터가 공유된다.
+ * Redis 장애 시에는 가용성을 위해 요청을 통과시킨다(fail-open).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final String KEY_PREFIX = "rate-limit:";
+
+    // INCR 후 카운터가 처음 생성된 경우(==1)에만 TTL을 설정하여 고정 시간창을 원자적으로 적용한다.
+    // INCR/EXPIRE 분리 시 둘 사이에 장애가 나면 TTL 없는 영구 키가 남는 문제를 방지한다.
+    private static final RedisScript<Long> INCREMENT_WITH_EXPIRE = new DefaultRedisScript<>(
+            "local count = redis.call('INCR', KEYS[1]) "
+                    + "if count == 1 then redis.call('PEXPIRE', KEYS[1], ARGV[1]) end "
+                    + "return count",
+            Long.class);
+
+    private final StringRedisTemplate redisTemplate;
+    private final RateLimitRules rateLimitRules;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        RateLimitRule rule = matchRule(request);
+        if (rule == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String clientIp = resolveClientIp(request);
+        if (isLimitExceeded(rule, clientIp)) {
+            writeTooManyRequests(response, rule);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private RateLimitRule matchRule(HttpServletRequest request) {
+        String method = request.getMethod();
+        String path = request.getRequestURI();
+
+        for (RateLimitRule rule : rateLimitRules.rules()) {
+            if (!rule.method().matches(method)) {
+                continue;
+            }
+            boolean pathMatched = rule.pathPatterns().stream()
+                    .anyMatch(pattern -> pathMatcher.match(pattern, path));
+            if (pathMatched) {
+                return rule;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isLimitExceeded(RateLimitRule rule, String clientIp) {
+        String key = KEY_PREFIX + rule.name() + ":" + clientIp;
+
+        try {
+            Long count = redisTemplate.execute(
+                    INCREMENT_WITH_EXPIRE,
+                    List.of(key),
+                    String.valueOf(rule.window().toMillis()));
+            if (count == null) {
+                return false;
+            }
+            return count > rule.limit();
+        } catch (Exception e) {
+            // Redis 장애 시 가용성을 우선하여 통과시킨다.
+            log.warn("Rate limit check failed for key {}, allowing request", key, e);
+            return false;
+        }
+    }
+
+    private void writeTooManyRequests(HttpServletResponse response, RateLimitRule rule) throws IOException {
+        long retryAfterSeconds = Math.max(1, rule.window().getSeconds());
+
+        if (response.isCommitted()) {
+            return;
+        }
+
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(
+                "{\"title\":\"Too Many Requests\",\"status\":429,"
+                        + "\"detail\":\"요청이 너무 많습니다. 잠시 후 다시 시도해주세요.\"}");
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        // raw X-Forwarded-For 직접 파싱은 스푸핑에 취약하므로 사용하지 않는다.
+        // 운영은 server.forward-headers-strategy=framework 로 신뢰된 프록시의 XFF만 반영되어
+        // getRemoteAddr()가 실제 클라이언트 IP를 반환한다. 로컬은 직접 연결 IP를 사용한다.
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRule.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRule.java
@@ -1,0 +1,23 @@
+package com.dongsoop.dongsoop.common.ratelimit;
+
+import java.time.Duration;
+import java.util.List;
+import org.springframework.http.HttpMethod;
+
+/**
+ * Rate Limit 규칙. 특정 HTTP 메서드 + 경로 패턴 묶음에 대해 시간창(window) 동안 허용 횟수(limit)를 정의한다.
+ *
+ * @param name        Redis 키 prefix 및 로깅에 사용하는 식별자
+ * @param method      적용할 HTTP 메서드
+ * @param pathPatterns Ant 스타일 경로 패턴 목록
+ * @param limit       window 동안 허용하는 최대 요청 수
+ * @param window      카운터가 유지되는 시간창
+ */
+public record RateLimitRule(
+        String name,
+        HttpMethod method,
+        List<String> pathPatterns,
+        int limit,
+        Duration window
+) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRuleConfig.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRuleConfig.java
@@ -1,0 +1,51 @@
+package com.dongsoop.dongsoop.common.ratelimit;
+
+import java.time.Duration;
+import java.util.List;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+
+/**
+ * Rate Limit 규칙 정의. 인증/이메일/검색 등 남용 위험이 높은 엔드포인트를 보호한다.
+ *
+ * <p>한도/시간창 조정 시 이 클래스만 수정하면 된다. (향후 외부 설정으로 이관 가능)
+ */
+@Configuration
+public class RateLimitRuleConfig {
+
+    @Bean
+    public RateLimitRules rateLimitRules() {
+        return new RateLimitRules(List.of(
+                new RateLimitRule(
+                        "login",
+                        HttpMethod.POST,
+                        List.of("/member/login", "/oauth2/kakao", "/oauth2/google", "/oauth2/apple"),
+                        5,
+                        Duration.ofMinutes(1)),
+                new RateLimitRule(
+                        "email",
+                        HttpMethod.POST,
+                        List.of("/mail-verify/send", "/mail-verify/send/password-update"),
+                        5,
+                        Duration.ofMinutes(1)),
+                new RateLimitRule(
+                        "search",
+                        HttpMethod.GET,
+                        List.of("/search/**"),
+                        30,
+                        Duration.ofMinutes(1))));
+    }
+
+    /**
+     * RateLimitFilter는 SecurityFilterChain에서만 실행되도록 하고, 서블릿 컨테이너의 자동 등록은 비활성화한다.
+     * (자동 등록 시 보안 체인과 합쳐 요청당 2회 실행되어 카운트가 중복된다.)
+     */
+    @Bean
+    public FilterRegistrationBean<RateLimitFilter> rateLimitFilterRegistration(RateLimitFilter rateLimitFilter) {
+        FilterRegistrationBean<RateLimitFilter> registration = new FilterRegistrationBean<>(rateLimitFilter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRules.java
+++ b/src/main/java/com/dongsoop/dongsoop/common/ratelimit/RateLimitRules.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.common.ratelimit;
+
+import java.util.List;
+
+/**
+ * Rate Limit 규칙 묶음 홀더.
+ *
+ * <p>{@code List<RateLimitRule>}를 직접 빈으로 주입하면 Spring이 "RateLimitRule 타입 빈 수집"으로
+ * 해석해 빈 리스트가 주입되는 함정이 있어, 전용 홀더 타입으로 감싸 모호성을 제거한다.
+ */
+public record RateLimitRules(List<RateLimitRule> rules) {
+}

--- a/src/main/java/com/dongsoop/dongsoop/s3/LocalS3ServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/LocalS3ServiceImpl.java
@@ -1,5 +1,7 @@
 package com.dongsoop.dongsoop.s3;
 
+import com.dongsoop.dongsoop.s3.validator.FileValidator;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -7,11 +9,17 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @Profile({"local", "test"})
+@RequiredArgsConstructor
 @Slf4j
 public class LocalS3ServiceImpl implements S3Service {
 
+    private final FileValidator fileValidator;
+
     @Override
     public String upload(MultipartFile file, String dirName, long boardId) {
+        // 실제 업로드는 하지 않지만, 검증 동작은 운영과 동일하게 유지하여 개발 단계에서 결함을 잡는다.
+        fileValidator.validate(file);
+
         log.info("Local S3 Service - upload called. No operation performed.");
         return "uploaded_file_placeholder_url";
     }

--- a/src/main/java/com/dongsoop/dongsoop/s3/S3ServiceImpl.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/S3ServiceImpl.java
@@ -1,8 +1,8 @@
 package com.dongsoop.dongsoop.s3;
 
+import com.dongsoop.dongsoop.s3.validator.FileValidator;
+import com.dongsoop.dongsoop.s3.validator.ImageContentType;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class S3ServiceImpl implements S3Service {
 
     private final S3Client client;
+    private final FileValidator fileValidator;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -30,28 +31,22 @@ public class S3ServiceImpl implements S3Service {
     private String namespace;
 
     public String upload(MultipartFile file, String dirName, long boardId) throws IOException {
-        String fileName = file.getOriginalFilename();
+        // 매직바이트로 실제 이미지 타입을 검증하고, 저장명/Content-Type은 클라이언트 입력이 아닌 판별 결과로 결정한다.
+        ImageContentType contentType = fileValidator.validate(file);
 
-        int separateIndex = fileName.lastIndexOf(".");
-        String extension = fileName.substring(separateIndex);
-        String saveFileName = UUID.randomUUID() + extension;
+        String saveFileName = UUID.randomUUID() + "." + contentType.getExtension();
         String saveFilePath = dirName + "/" + boardId + "/" + saveFileName;
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(saveFilePath)
-                .contentType(file.getContentType())
+                .contentType(contentType.getMimeType())
                 .build();
 
         client.putObject(
                 putObjectRequest,
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize())
         );
-
-        String encodedPath = URLEncoder.encode(saveFilePath, StandardCharsets.UTF_8)
-                .replace("+", "%20") // 공백 처리
-                .replace("%2F", "/") // 슬래시 복구
-                .replace("%2f", "/");
 
         return String.format("https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
                 region, namespace, bucket, saveFilePath);

--- a/src/main/java/com/dongsoop/dongsoop/s3/exception/FileTooLargeException.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/exception/FileTooLargeException.java
@@ -1,0 +1,12 @@
+package com.dongsoop.dongsoop.s3.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class FileTooLargeException extends CustomException {
+
+    public FileTooLargeException(long maxSizeBytes) {
+        super("업로드 가능한 최대 파일 크기(" + (maxSizeBytes / (1024 * 1024)) + "MB)를 초과했습니다.",
+                HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/s3/exception/InvalidFileException.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/exception/InvalidFileException.java
@@ -1,0 +1,11 @@
+package com.dongsoop.dongsoop.s3.exception;
+
+import com.dongsoop.dongsoop.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFileException extends CustomException {
+
+    public InvalidFileException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/s3/validator/FileValidator.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/validator/FileValidator.java
@@ -1,0 +1,60 @@
+package com.dongsoop.dongsoop.s3.validator;
+
+import com.dongsoop.dongsoop.s3.exception.FileTooLargeException;
+import com.dongsoop.dongsoop.s3.exception.InvalidFileException;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 업로드 파일을 검증한다: 빈 파일 차단, 크기 상한, 매직바이트 기반 실제 이미지 타입 판별.
+ *
+ * <p>확장자/Content-Type 같은 클라이언트 제공 값은 신뢰하지 않으며,
+ * 반환된 {@link ImageContentType}으로 저장 시 사용할 정규 MIME/확장자를 결정한다.
+ */
+@Component
+@Slf4j
+public class FileValidator {
+
+    private static final long MAX_SIZE_BYTES = 10L * 1024 * 1024; // 10MB
+
+    /**
+     * @return 매직바이트로 판별된 이미지 타입 (저장 시 정규 MIME/확장자로 사용)
+     * @throws InvalidFileException  파일이 비었거나 허용되지 않은 형식일 때
+     * @throws FileTooLargeException 크기 상한을 초과했을 때
+     */
+    public ImageContentType validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidFileException("업로드할 파일이 없습니다.");
+        }
+
+        if (file.getSize() > MAX_SIZE_BYTES) {
+            throw new FileTooLargeException(MAX_SIZE_BYTES);
+        }
+
+        ImageContentType detectedType = detectType(file);
+        if (detectedType == null) {
+            throw new InvalidFileException("허용되지 않은 파일 형식입니다. (jpg, png, gif, webp 이미지만 가능)");
+        }
+
+        return detectedType;
+    }
+
+    private ImageContentType detectType(MultipartFile file) {
+        byte[] header = new byte[ImageSignatureDetector.HEADER_SIZE];
+
+        try (InputStream inputStream = file.getInputStream()) {
+            int read = inputStream.readNBytes(header, 0, header.length);
+            if (read < ImageSignatureDetector.HEADER_SIZE) {
+                return null;
+            }
+        } catch (IOException e) {
+            log.warn("Failed to read uploaded file header", e);
+            throw new InvalidFileException("파일을 읽을 수 없습니다.");
+        }
+
+        return ImageSignatureDetector.detect(header);
+    }
+}

--- a/src/main/java/com/dongsoop/dongsoop/s3/validator/ImageContentType.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/validator/ImageContentType.java
@@ -1,0 +1,22 @@
+package com.dongsoop.dongsoop.s3.validator;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 업로드를 허용하는 이미지 타입. 저장 시 사용할 정규 MIME과 확장자를 보유한다.
+ *
+ * <p>실제 바이트 시그니처 판별은 {@link ImageSignatureDetector}가 담당한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ImageContentType {
+
+    JPEG("image/jpeg", "jpg"),
+    PNG("image/png", "png"),
+    GIF("image/gif", "gif"),
+    WEBP("image/webp", "webp");
+
+    private final String mimeType;
+    private final String extension;
+}

--- a/src/main/java/com/dongsoop/dongsoop/s3/validator/ImageSignatureDetector.java
+++ b/src/main/java/com/dongsoop/dongsoop/s3/validator/ImageSignatureDetector.java
@@ -1,0 +1,82 @@
+package com.dongsoop.dongsoop.s3.validator;
+
+/**
+ * 파일 앞부분의 매직바이트(시그니처)로 실제 이미지 타입을 판별한다.
+ *
+ * <p>클라이언트가 보낸 확장자/Content-Type을 신뢰하지 않고 바이트로만 판단하여
+ * 위장 파일(예: .png로 위장한 HTML/SVG) 업로드를 차단한다.
+ */
+public final class ImageSignatureDetector {
+
+    public static final int HEADER_SIZE = 16;
+
+    private ImageSignatureDetector() {
+    }
+
+    /**
+     * @param header 파일 앞 {@link #HEADER_SIZE} 바이트
+     * @return 일치하는 이미지 타입, 없으면 null
+     */
+    public static ImageContentType detect(byte[] header) {
+        if (header == null || header.length < HEADER_SIZE) {
+            return null;
+        }
+
+        if (isJpeg(header)) {
+            return ImageContentType.JPEG;
+        }
+        if (isPng(header)) {
+            return ImageContentType.PNG;
+        }
+        if (isGif(header)) {
+            return ImageContentType.GIF;
+        }
+        if (isWebp(header)) {
+            return ImageContentType.WEBP;
+        }
+
+        return null;
+    }
+
+    // FF D8 FF
+    private static boolean isJpeg(byte[] h) {
+        return matches(h, 0, 0xFF, 0xD8, 0xFF);
+    }
+
+    // 89 50 4E 47 0D 0A 1A 0A
+    private static boolean isPng(byte[] h) {
+        return matches(h, 0, 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A);
+    }
+
+    // 47 49 46 38 ("GIF8")
+    private static boolean isGif(byte[] h) {
+        return matches(h, 0, 0x47, 0x49, 0x46, 0x38);
+    }
+
+    // "RIFF"(0..3) + "WEBP"(8..11) + VP8 청크 헤더(12..15: "VP8 " | "VP8L" | "VP8X")
+    private static boolean isWebp(byte[] h) {
+        boolean riffWebp = matches(h, 0, 0x52, 0x49, 0x46, 0x46)
+                && matches(h, 8, 0x57, 0x45, 0x42, 0x50);
+        if (!riffWebp) {
+            return false;
+        }
+
+        return matches(h, 12, 0x56, 0x50, 0x38, 0x20)   // "VP8 " (lossy)
+                || matches(h, 12, 0x56, 0x50, 0x38, 0x4C) // "VP8L" (lossless)
+                || matches(h, 12, 0x56, 0x50, 0x38, 0x58); // "VP8X" (extended)
+    }
+
+    private static boolean matches(byte[] header, int offset, int... expected) {
+        if (header.length < offset + expected.length) {
+            return false;
+        }
+
+        for (int i = 0; i < expected.length; i++) {
+            if ((header[offset + i] & 0xFF) != expected[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,9 @@
 server:
   address: ${SERVER_ADDRESS}
   port: ${SERVER_PORT}
+  # LB/리버스 프록시(OCI/Nginx) 뒤에서 X-Forwarded-* 를 신뢰 처리하여 request.getRemoteAddr()가 실제 클라이언트 IP를 반환하게 한다.
+  # (애플리케이션에서 raw XFF 헤더를 직접 파싱하면 스푸핑에 취약하므로 프레임워크 처리에 위임한다.)
+  forward-headers-strategy: framework
 
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
       local: local
       prod: prod
     default: local
+  servlet:
+    multipart:
+      # 컨테이너 기본값(1MB)을 FileValidator의 검증 상한(10MB)과 일치시킨다. (이미지 최대 3장)
+      max-file-size: 10MB
+      max-request-size: 35MB
 
 logging:
   config: classpath:logback.xml

--- a/src/test/java/com/dongsoop/dongsoop/chat/ChatControllerTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/chat/ChatControllerTest.java
@@ -6,6 +6,7 @@ import com.dongsoop.dongsoop.chat.service.ChatParticipantService;
 import com.dongsoop.dongsoop.chat.service.ChatRoomService;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.chat.validator.ChatValidator;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.member.entity.Member;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
@@ -42,6 +43,8 @@ class ChatControllerTest {
     private MemberService memberService;
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/feedback/FeedbackContentTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/feedback/FeedbackContentTest.java
@@ -10,6 +10,7 @@ import com.dongsoop.dongsoop.feedback.controller.FeedbackController;
 import com.dongsoop.dongsoop.feedback.entity.ServiceFeature;
 import com.dongsoop.dongsoop.feedback.service.FeedbackService;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -36,6 +37,8 @@ class FeedbackContentTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/member/MemberLoginTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/member/MemberLoginTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
 import com.dongsoop.dongsoop.member.service.LoginNotificationService;
@@ -43,6 +44,8 @@ class MemberLoginTest {
     private FCMService fcmService;
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private LoginNotificationService loginNotificationService;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/memberblock/MemberBlockTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/memberblock/MemberBlockTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -59,6 +60,8 @@ public class MemberBlockTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/memberblock/MemberUnblockTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/memberblock/MemberUnblockTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.chat.repository.RedisChatRepository;
 import com.dongsoop.dongsoop.chat.service.ChatService;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -57,6 +58,8 @@ public class MemberUnblockTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/memberdevice/MemberDeviceControllerTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/memberdevice/MemberDeviceControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.jwt.service.DeviceBlacklistService;
 import com.dongsoop.dongsoop.member.service.MemberService;
@@ -52,6 +53,8 @@ class MemberDeviceControllerTest {
     private DeviceBlacklistService deviceBlacklistService;
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/notice/keyword/NoticeKeywordControllerTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/notice/keyword/NoticeKeywordControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -58,6 +59,8 @@ class NoticeKeywordControllerTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
 
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;

--- a/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardRecruitDateTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -62,6 +63,8 @@ class ProjectBoardRecruitDateTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/projectBoard/ProjectBoardStartAtTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -50,6 +51,8 @@ class ProjectBoardStartAtTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/report/ReportControllerTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/report/ReportControllerTest.java
@@ -1,6 +1,7 @@
 package com.dongsoop.dongsoop.report;
 
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -34,6 +35,8 @@ class ReportControllerTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardRecruitDateTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
@@ -62,6 +63,8 @@ class StudyBoardRecruitDateTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/studyBoard/StudyBoardStartAtTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -50,6 +51,8 @@ class StudyBoardStartAtTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardDepartmentSizeTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardDepartmentSizeTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -46,6 +47,8 @@ class TutoringBoardDepartmentSizeTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardRecruitDateTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.department.repository.DepartmentRepository;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.member.service.MemberService;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
@@ -62,6 +63,8 @@ class TutoringBoardRecruitDateTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean

--- a/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/tutoring/TutoringBoardStartAtTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dongsoop.dongsoop.department.entity.Department;
 import com.dongsoop.dongsoop.department.entity.DepartmentType;
 import com.dongsoop.dongsoop.appcheck.FirebaseAppCheck;
+import com.dongsoop.dongsoop.common.ratelimit.RateLimitFilter;
 import com.dongsoop.dongsoop.jwt.filter.JwtFilter;
 import com.dongsoop.dongsoop.memberdevice.service.MemberDeviceService;
 import com.dongsoop.dongsoop.memberdevice.util.DeviceUtil;
@@ -51,6 +52,8 @@ class TutoringBoardStartAtTest {
 
     @MockitoBean
     private JwtFilter jwtFilter;
+    @MockitoBean
+    private RateLimitFilter rateLimitFilter;
     @MockitoBean
     private FirebaseAppCheck firebaseAppCheck;
     @MockitoBean


### PR DESCRIPTION
## 개요

KISA AI 보안 가이드라인 / OWASP Top 10 기준 **Priority 1 보안 취약점** 중 3건을 조치합니다. (AI 텍스트 필터링 P1-2/P1-5는 별도 AI 서비스 영역이라 제외)

- **P1-4** WebSocket CORS 제한
- **P1-1** 파일 업로드 보안 (CRITICAL)
- **P1-3** Rate Limiting

## 변경 내용

### 🔒 P1-4 — WebSocket CORS (`fix(security)`)
- STOMP 엔드포인트(`/ws/chat`, `/ws/blinddate`)의 `setAllowedOriginPatterns("*")` → `authentication.origins` 화이트리스트 재사용
- CSWSH(교차 출처 WebSocket 하이재킹) 방지, REST/WebSocket CORS 정책 일원화

### 🔥 P1-1 — 파일 업로드 보안 (`feat(security)`)
- **매직바이트 기반 실제 이미지 타입 판별**(JPEG/PNG/GIF/WEBP) — 클라이언트 확장자/Content-Type 불신
  - `FileValidator`, `ImageSignatureDetector`, `ImageContentType`
- 저장 파일명·Content-Type을 **판별 결과**로 결정 → 확장자 위장(.png로 위장한 HTML/SVG)·stored XSS 차단
- 빈 파일/크기 상한(10MB) 검증, `getOriginalFilename()` NPE 및 dead code 제거
- multipart 한도 `max-file-size: 10MB` / `max-request-size: 35MB` (기본 1MB가 검증을 무력화하던 문제 해결)
- `MaxUploadSizeExceededException` → **413** 매핑

### 🚦 P1-3 — Rate Limiting (`feat(security)`)
- IP 기준 제한: 로그인/소셜 `5회/분`, 이메일 발송 `5회/분`, 검색 `30회/분`
- Redis **Lua 스크립트로 INCR+PEXPIRE 원자 처리**(고정 시간창) → TTL 유실 영구 키 방지
- `RateLimitFilter`를 `JwtFilter` 앞에 등록 + `FilterRegistrationBean.setEnabled(false)`로 서블릿 자동 등록 차단(이중 카운트 방지)
- `List<RateLimitRule>` 주입 함정을 `RateLimitRules` 홀더로 회피
- raw XFF 파싱 제거 → prod `forward-headers-strategy: framework` 위임(IP 스푸핑 방지), Redis 장애 시 fail-open

## 검증

- ✅ `./gradlew compileJava` 통과
- ✅ 독립 코드 리뷰 1회 + 지적된 HIGH 5건(멀티파트 1MB 무력화, XFF 스푸핑, INCR/EXPIRE 비원자, WEBP 청크 미검증, 필터 이중등록) 반영

## ⚠️ 머지 전 확인 필요

- [ ] **WebSocket 네이티브(앱) 클라이언트 Origin** — `"*"` → 화이트리스트로 좁혔습니다. Origin 헤더를 보내지 않는 네이티브 클라는 통과되어 보통 안전하나, 앱이 WebSocket에 Origin을 실어 보낼 경우 핸드셰이크가 막힐 수 있어 `/ws/chat`·`/ws/blinddate` **실제 앱 스테이징 연결 테스트** 필요
- [ ] 운영 LB가 인바운드 `X-Forwarded-For`를 덮어쓰는지(스푸핑 방지 전제) 확인
- [ ] (선택) 단위 테스트 추가: `ImageSignatureDetector`, `FileValidator`, `RateLimitFilter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
