### PR TITLE
feat: 개인 일정에 색상(color) 필드 추가

### DIFF
--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/CreateMemberScheduleRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/CreateMemberScheduleRequest.java
@@ -28,7 +28,7 @@ public class CreateMemberScheduleRequest {
     @NotNull
     private LocalDateTime endAt;
 
-    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "색상은 유효한 HEX 형식이어야 합니다 (예: #FFFFFF)")
+    @Pattern(regexp = "^[A-Fa-f0-9]{6}$", message = "색상은 # 없이 6자리 HEX 형식이어야 합니다 (예: FFFFFF)")
     private String color;
 
     public MemberSchedule toEntity() {

--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/CreateMemberScheduleRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/CreateMemberScheduleRequest.java
@@ -2,6 +2,7 @@ package com.dongsoop.dongsoop.calendar.dto;
 
 import com.dongsoop.dongsoop.calendar.entity.MemberSchedule;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,12 +28,16 @@ public class CreateMemberScheduleRequest {
     @NotNull
     private LocalDateTime endAt;
 
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "색상은 유효한 HEX 형식이어야 합니다 (예: #FFFFFF)")
+    private String color;
+
     public MemberSchedule toEntity() {
         return MemberSchedule.builder()
                 .title(title)
                 .location(location)
                 .startAt(startAt)
                 .endAt(endAt)
+                .color(color)
                 .build();
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/MemberScheduleUpdateRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/MemberScheduleUpdateRequest.java
@@ -22,6 +22,6 @@ public class MemberScheduleUpdateRequest {
 
     private LocalDateTime endAt;
 
-    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "색상은 유효한 HEX 형식이어야 합니다 (예: #FFFFFF)")
+    @Pattern(regexp = "^[A-Fa-f0-9]{6}$", message = "색상은 # 없이 6자리 HEX 형식이어야 합니다 (예: FFFFFF)")
     private String color;
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/MemberScheduleUpdateRequest.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/MemberScheduleUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.dongsoop.dongsoop.calendar.dto;
 
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,4 +21,7 @@ public class MemberScheduleUpdateRequest {
     private LocalDateTime startAt;
 
     private LocalDateTime endAt;
+
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "색상은 유효한 HEX 형식이어야 합니다 (예: #FFFFFF)")
+    private String color;
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/dto/ScheduleDetails.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/dto/ScheduleDetails.java
@@ -24,4 +24,6 @@ public class ScheduleDetails {
     private LocalDateTime endAt;
 
     private ScheduleType type;
+
+    private String color;
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/entity/MemberSchedule.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/entity/MemberSchedule.java
@@ -50,6 +50,9 @@ public class MemberSchedule extends BaseEntity {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
+    @Column(name = "color", length = 7)
+    private String color;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     @Getter
@@ -72,6 +75,7 @@ public class MemberSchedule extends BaseEntity {
                 .startAt(startAt)
                 .endAt(endAt)
                 .type(ScheduleType.MEMBER)
+                .color(color)
                 .build();
     }
 
@@ -90,6 +94,10 @@ public class MemberSchedule extends BaseEntity {
 
         if (request.getEndAt() != null) {
             this.endAt = request.getEndAt();
+        }
+
+        if (request.getColor() != null) {
+            this.color = request.getColor();
         }
     }
 }

--- a/src/main/java/com/dongsoop/dongsoop/calendar/entity/MemberSchedule.java
+++ b/src/main/java/com/dongsoop/dongsoop/calendar/entity/MemberSchedule.java
@@ -50,7 +50,7 @@ public class MemberSchedule extends BaseEntity {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
-    @Column(name = "color", length = 7)
+    @Column(name = "color", length = 6)
     private String color;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/test/java/com/dongsoop/dongsoop/notification/CalendarNotificationSettingTest.java
+++ b/src/test/java/com/dongsoop/dongsoop/notification/CalendarNotificationSettingTest.java
@@ -110,11 +110,11 @@ public class CalendarNotificationSettingTest extends AbstractIntegrationTest {
 
         // 회원 일정 추가
         MemberSchedule memberSchedule1 = new MemberSchedule(null, "title", "content", LocalDateTime.now(),
-                LocalDateTime.now(), member1);
+                LocalDateTime.now(), null, member1);
         MemberSchedule memberSchedule2 = new MemberSchedule(null, "title", "content", LocalDateTime.now(),
-                LocalDateTime.now(), member2);
+                LocalDateTime.now(), null, member2);
         MemberSchedule memberSchedule3 = new MemberSchedule(null, "title", "content", LocalDateTime.now(),
-                LocalDateTime.now(), member3);
+                LocalDateTime.now(), null, member3);
 
         memberScheduleRepository.saveAll(List.of(memberSchedule1, memberSchedule2, memberSchedule3));
 


### PR DESCRIPTION
## Summary

- `MemberSchedule` 엔티티에 `color` 컬럼 추가 (HEX 형식, `#RRGGBB` 또는 `#RGB`, 최대 7자, nullable)
- `ScheduleDetails` 응답 DTO에 `color` 필드 포함 → 리스트/상세 조회 시 색상 반환
- `CreateMemberScheduleRequest`에 `color` 필드 추가 및 HEX 형식 유효성 검사 (`@Pattern`)
- `MemberScheduleUpdateRequest`에 `color` 필드 추가 및 HEX 형식 유효성 검사 (`@Pattern`)
- `MemberSchedule.toEntity()`, `toDetails()`, `update()` 메서드에 color 반영

## Test plan

- [ ] `POST /schedule/member` — `color: "#FF5733"` 포함 요청 시 정상 생성 확인
- [ ] `POST /schedule/member` — `color: "invalid"` 포함 요청 시 400 응답 확인
- [ ] `PATCH /schedule/member/{id}` — color 수정 후 조회 시 변경 반영 확인
- [ ] `GET /schedule/{yearMonth}` — 응답 DTO에 `color` 필드 포함 확인
- [ ] color 미입력(null) 시 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정에 색상을 지정할 수 있는 기능이 추가되었습니다. HEX 형식(`#RRGGBB` 또는 `#RGB`)의 색상을 지원하며, 일정 생성 및 수정 시 색상을 설정하고 변경할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->