### PR TITLE
fix: /notice/keywords 엔드포인트를 USER 권한으로 제한

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,6 @@ authentication:
       /meal/current,
       /error,
       /ws/**,
-      /notice/**,
       /timetable/**,
       /token/reissue,
       /search/**,
@@ -47,7 +46,9 @@ authentication:
       /oauth2/apple/callback,
       /web-app-check
     user:
-      /test/user
+      /test/user,
+      /notice/keywords,
+      /notice/keywords/**
     admin:
       /admin
   origins:
@@ -69,7 +70,6 @@ authentication:
         /member/login,
         /member/signup,
         /mail-verify/**,
-        /notice/**,
         /oauth2/authorization,
         /ws/**,
         /web-app-check

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ authentication:
       /meal/current,
       /error,
       /ws/**,
+      /notice/**,
       /timetable/**,
       /token/reissue,
       /search/**,


### PR DESCRIPTION
## Summary
- `permitAll`에 등록된 `/notice/**`가 JWT 필터 ignore 목록에도 포함되어, Bearer 토큰을 전송해도 SecurityContext에 인증 정보가 설정되지 않는 문제 수정
- `/notice/keywords` (GET/POST/DELETE) 를 USER 권한 경로로 이동하여 토큰 기반 인증이 정상 동작하도록 수정

## Changes
- `authentication.path.all`에서 `/notice/**` 제거
- `authentication.filter.ignore.paths`에서 `/notice/**` 제거
- `authentication.path.user`에 `/notice/keywords`, `/notice/keywords/**` 추가

## Test plan
- [ ] Bearer 토큰 없이 `GET /notice/keywords` 호출 → 401 응답 확인
- [ ] 유효한 Bearer 토큰으로 `GET /notice/keywords` 호출 → 200 + 본인 키워드 목록 반환 확인
- [ ] 유효한 Bearer 토큰으로 `POST /notice/keywords` 호출 → 201 응답 확인
- [ ] 유효한 Bearer 토큰으로 `DELETE /notice/keywords/{id}` 호출 → 204 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 공지사항 관련 엔드포인트의 접근 제어 설정을 조정했습니다. 키워드 기능 관련 경로의 인증 요구사항이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->